### PR TITLE
consistently use deploy_name and maturity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ yarn.lock
 daac-repo
 daac
 workflows
+.secrets

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ link-daac:
 	ln -s ${DAAC_REPO} ./daac-repo
 	ln -s daac-repo/daac ./daac
 	ln -s daac-repo/workflows ./workflows
+	ln -s daac-repo/cumulus/secrets ./.secrets
 
 checkout-daac:
 	git clone ${DAAC_REPO} daac-repo
@@ -43,17 +44,17 @@ checkout-daac:
 tf-init:
 	cd tf
 	terraform init -reconfigure -input=false
-	terraform workspace new ${MATURITY} || terraform workspace select ${MATURITY}
+	terraform workspace new ${DEPLOY_NAME}-${MATURITY} || terraform workspace select ${DEPLOY_NAME}-${MATURITY}
 
 %-init:
 	cd $*
 	rm -f .terraform/environment
 	terraform init -reconfigure -input=false \
 		-backend-config "region=${AWS_REGION}" \
-		-backend-config "bucket=cumulus-${MATURITY}-tf-state" \
+		-backend-config "bucket=${DEPLOY_NAME}-cumulus-${MATURITY}-tf-state" \
 		-backend-config "key=$*/terraform.tfstate" \
-		-backend-config "dynamodb_table=cumulus-${MATURITY}-tf-locks"
-	terraform workspace new ${DEPLOY_NAME} || terraform workspace select ${DEPLOY_NAME}
+		-backend-config "dynamodb_table=${DEPLOY_NAME}-cumulus-${MATURITY}-tf-locks"
+	terraform workspace new ${DEPLOY_NAME}-${MATURITY} || terraform workspace select ${DEPLOY_NAME}-${MATURITY}
 
 modules = tf daac data-persistence cumulus workflows
 init-modules := $(modules:%-init=%)
@@ -65,9 +66,9 @@ validate: $(init-modules)
 
 tf: tf-init
 	cd tf
-	terraform import -input=false aws_s3_bucket.tf-state-bucket cumulus-${MATURITY}-tf-state || true
-	terraform import -input=false aws_dynamodb_table.tf-locks-table cumulus-${MATURITY}-tf-locks || true
-	terraform refresh -input=false -state=terraform.tfstate.d/${MATURITY}/terraform.tfstate
+	terraform import -input=false aws_s3_bucket.tf-state-bucket ${DEPLOY_NAME}-cumulus-${MATURITY}-tf-state || true
+	terraform import -input=false aws_dynamodb_table.tf-locks-table ${DEPLOY_NAME}-cumulus-${MATURITY}-tf-locks || true
+	terraform refresh -input=false -state=terraform.tfstate.d/${DEPLOY_NAME}-${MATURITY}/terraform.tfstate
 	terraform apply -input=false -auto-approve
 
 daac: daac-init
@@ -123,10 +124,10 @@ cumulus: cumulus-init
 		$$SECRETS_OPT \
 		-input=false \
 		-auto-approve
-	if [ $$? -ne 0 ] # Workaround random Cumulus deploy fails
-	then
-		terraform apply -input=false -auto-approve
-	fi
+#	if [ $$? -ne 0 ] # Workaround random Cumulus deploy fails
+#	then
+#		terraform apply -input=false -auto-approve
+#	fi
 
 workflows: workflows-init
 	cd workflows

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ cumulus: cumulus-init
 		$$SECRETS_OPT \
 		-input=false \
 		-auto-approve
-#	if [ $$? -ne 0 ] # Workaround random Cumulus deploy fails
-#	then
-#		terraform apply -input=false -auto-approve
-#	fi
+	if [ $$? -ne 0 ] # Workaround random Cumulus deploy fails
+	then
+		terraform apply -input=false -auto-approve
+	fi
 
 workflows: workflows-init
 	cd workflows

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -11,6 +11,7 @@ module "cumulus" {
   ecs_cluster_min_size            = 1
   ecs_cluster_desired_size        = 1
   ecs_cluster_max_size            = 2
+  ecs_cluster_instance_image_id   = var.ecs_cluster_instance_image_id
   key_name                        = var.key_name
 
   urs_url             = var.urs_url
@@ -49,7 +50,7 @@ module "cumulus" {
   saml_entity_id                  = var.saml_entity_id
   saml_assertion_consumer_service = var.saml_assertion_consumer_service
   saml_idp_login                  = var.saml_idp_login
-  saml_launchpad_metadata_path    = var.saml_launchpad_metadata_path
+  saml_launchpad_metadata_url     = var.saml_launchpad_metadata_url
 
   token_secret = var.token_secret
 

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.17.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.18.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
   cumulus_message_adapter_lambda_layer_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
   prefix = local.prefix
@@ -84,13 +84,13 @@ locals {
   prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
 
   daac_remote_state_config = {
-    bucket = "cumulus-${var.MATURITY}-tf-state"
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state"
     key    = "daac/terraform.tfstate"
     region = "${data.aws_region.current.name}"
   }
 
   data_persistence_remote_state_config = {
-    bucket = "cumulus-${var.MATURITY}-tf-state"
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state"
     key    = "data-persistence/terraform.tfstate"
     region = "${data.aws_region.current.name}"
   }
@@ -150,13 +150,13 @@ data "aws_subnet_ids" "subnet_ids" {
 
 data "terraform_remote_state" "daac" {
   backend = "s3"
-  workspace = "${var.DEPLOY_NAME}"
+  workspace = "${var.DEPLOY_NAME}-${var.MATURITY}"
   config  = local.daac_remote_state_config
 }
 
 data "terraform_remote_state" "data_persistence" {
   backend = "s3"
-  workspace = "${var.DEPLOY_NAME}"
+  workspace = "${var.DEPLOY_NAME}-${var.MATURITY}"
   config  = local.data_persistence_remote_state_config
 }
 

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -5,9 +5,9 @@ module "cumulus" {
   prefix = local.prefix
 
   vpc_id = data.aws_vpc.application_vpcs.id
-  lambda_subnet_ids = "${list(sort(data.aws_subnet_ids.subnet_ids.ids)[0])}"
+  lambda_subnet_ids = data.aws_subnet_ids.subnet_ids.ids
 
-  ecs_cluster_instance_subnet_ids = "${list(sort(data.aws_subnet_ids.subnet_ids.ids)[0])}"
+  ecs_cluster_instance_subnet_ids = data.aws_subnet_ids.subnet_ids.ids
   ecs_cluster_min_size            = 1
   ecs_cluster_desired_size        = 1
   ecs_cluster_max_size            = 2
@@ -147,6 +147,10 @@ data "aws_vpc" "application_vpcs" {
 
 data "aws_subnet_ids" "subnet_ids" {
   vpc_id = data.aws_vpc.application_vpcs.id
+
+  tags = {
+    Name = "Private application ${data.aws_region.current.name}a subnet"
+   }
 }
 
 data "terraform_remote_state" "daac" {

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -43,3 +43,13 @@ output "report_granules_sns_topic_arn" {
 output "report_pdrs_sns_topic_arn" {
   value = module.cumulus.report_pdrs_sns_topic_arn
 }
+
+output "subnet_ids" {
+  value = data.aws_subnet_ids.subnet_ids.ids
+}
+
+output "hello_world_task" {
+  value = {
+    task_arn = module.cumulus.hello_world_task.task_arn
+  }
+}

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -75,7 +75,7 @@ variable "saml_idp_login" {
   default = "N/A"
 }
 
-variable "saml_launchpad_metadata_path" {
+variable "saml_launchpad_metadata_url" {
   type    = string
   default = "N/A"
 }

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.17.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.18.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                     = local.prefix
   subnet_ids                 = "${list(sort(data.aws_subnet_ids.subnet_ids.ids)[0])}"

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -14,13 +14,15 @@ module "data_persistence" {
   source = "https://github.com/nasa/cumulus/releases/download/v1.18.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                     = local.prefix
-  subnet_ids                 = "${list(sort(data.aws_subnet_ids.subnet_ids.ids)[0])}"
+  subnet_ids                 = data.aws_subnet_ids.subnet_ids.ids
   include_elasticsearch      = var.include_elasticsearch
 }
 
 locals {
   prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
 }
+
+data "aws_region" "current" {}
 
 data "aws_vpc" "application_vpcs" {
   tags = {
@@ -30,4 +32,8 @@ data "aws_vpc" "application_vpcs" {
 
 data "aws_subnet_ids" "subnet_ids" {
   vpc_id = data.aws_vpc.application_vpcs.id
+
+  tags = {
+    Name = "Private application ${data.aws_region.current.name}a subnet"
+   }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -8,7 +8,7 @@ provider "aws" {
 }
 
 locals {
-  cumulus-prefix = "cumulus-${var.MATURITY}"
+  cumulus-prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
 }
 
 resource "aws_s3_bucket" "tf-state-bucket" {

--- a/tf/variables.tf
+++ b/tf/variables.tf
@@ -1,3 +1,7 @@
+variable "DEPLOY_NAME" {
+  type = string
+}
+
 variable "MATURITY" {
   type = string
   default = "dev"


### PR DESCRIPTION
When I tried to deploy, I had name collisions on S3 buckets due to not using the deploy_name at the beginning.  I also though it might be nice for the terraform workspaces to have both deploy_name and maturity in the name.  Also to avoid possible testing collisions.

I got to the `make cumulus` step and found that v1.17.0 seems to want to use and AMI that no longer exists, so I updated to v1.18.0.
