### PR TITLE
add .secrets symlink needed for local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ daac-repo
 daac
 workflows
 .python-version
+.secrets

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ link-daac:
 	ln -s ${DAAC_REPO} ./daac-repo
 	ln -s daac-repo/daac ./daac
 	ln -s daac-repo/workflows ./workflows
+	ln -s daac-repo/cumulus/secrets ./.secrets
 
 checkout-daac:
 	git clone ${DAAC_REPO} daac-repo


### PR DESCRIPTION
When running the makefile locally, it expects a .secrets symlink.  This commit adds that link.