### PR TITLE
Remove the use of the DAAC repo's data-persistence directory.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,16 +130,7 @@ daac:
 data-persistence: data-persistence-init
 	$(banner)
 	cd $@
-	if [ -f "../daac-repo/$@/variables/${MATURITY}.tfvars" ]
-	then
-		echo "***************************************************************"
-		export VARIABLES_OPT="-var-file=../daac-repo/$@/variables/${MATURITY}.tfvars"
-		echo "Found maturity-specific variables: $$VARIABLES_OPT"
-		echo "***************************************************************"
-	fi
 	terraform apply \
-		-var-file=../daac-repo/$@/terraform.tfvars \
-		$$VARIABLES_OPT \
 		-input=false \
 		-no-color \
 		-auto-approve


### PR DESCRIPTION
The default settings for the Cumulus data-persistence module is
sufficient for what we need to do, and I don't think we need the
ability to customize it in the DAAC repo. If wrong, we can add it
later.