### PR TITLE
updates for v1.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v1.22.1.0
+
+### CHANGES
+
+* Upgrade to Cumulus v1.22.1.
+* review Cumulus
+  [deployment instructions](https://github.com/nasa/Cumulus/releases/tag/v1.21.0)
+
 ## v1.21.0.0
 
 ### CHANGES

--- a/README.md
+++ b/README.md
@@ -97,6 +97,9 @@ account.
 
         (This assumes we've setup a named AWS credentials profile with the name `xyz-sandbox-cumulus`)
 
+        **NOTE**: this script is still a WIP and may not work
+        in all environments, contributions are welcome!
+
 1. Start the Docker container as shown above (`... make
    container-shell`), providing the `DAAC_DIR` variable you are
    working with.

--- a/README.md
+++ b/README.md
@@ -84,11 +84,24 @@ account.
 
 ### Deploying from the commandline
 
-0. Start the Docker container as shown above (`... make
+0. Create AWS Secret for TEA access with the [named AWS
+   Profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
+   that has permissions to deploy to the target NGAP account:
+
+        $ source setup_jwt_cookie.sh <profile-name> <deploy-name> <maturity>
+
+        e.g., to create a secret for XYZ DAAC's NGAP sandbox account with the initials
+        of a developer (to make the deployment unique) and a maturity of 'dev':
+
+        $ source setup_jwt_cookie.sh xyz-sandbox-cumulus kb dev
+
+        (This assumes we've setup a named AWS credentials profile with the name `xyz-sandbox-cumulus`)
+
+1. Start the Docker container as shown above (`... make
    container-shell`), providing the `DAAC_DIR` variable you are
    working with.
 
-1. Setup your environment with the [named AWS
+2. Setup your environment with the [named AWS
    Profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html)
    that has permissions to deploy to the target NGAP account:
 
@@ -101,7 +114,7 @@ account.
 
         (This assumes we've setup a named AWS credentials profile with the name `xyz-sandbox-cumulus`)
 
-2. See the [CIRRUS-DAAC
+4. See the [CIRRUS-DAAC
   README's](https://github.com/asfadmin/CIRRUS-DAAC/blob/master/README.md)
   instructions for creating local secrets files. These will be files
   located in the DAAC directory, and as the note describes below, are

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.21.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.22.1/terraform-aws-cumulus.zip//tf-modules/cumulus"
   cumulus_message_adapter_lambda_layer_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
   prefix = local.prefix

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -11,7 +11,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v1.21.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v1.22.1/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                     = local.prefix
   subnet_ids                 = data.aws_subnet_ids.subnet_ids.ids


### PR DESCRIPTION
This pull request contains the v1.22.1 updates plus a proposed modification to the README.

In version 1.19 of Cumulus a step was added to create the AWS Secret for TEA.  I added Brian's script to do that creation and noted it in the CHANGELOG, but never did update the README.  I think this needs to be the very first step in a new users deployment because it can't happen within Docker.  When I do try to run it in Docker I get a

```
No user exists for uid 2142656538
```

You might know a way around this, but for now, running it outside the container works.  Thoughts?


