### PR TITLE
archive_api_url is required for accessing dashboard via cloudfront

### DIFF
--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -69,6 +69,7 @@ module "cumulus" {
   dynamo_tables = data.terraform_remote_state.data_persistence.outputs.dynamo_tables
 
   archive_api_users = var.api_users
+  archive_api_url = var.archive_api_url
 
   distribution_url = var.distribution_url
   thin_egress_jwt_secret_name = "${local.prefix}-jwt_secret_for_tea"

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -193,6 +193,11 @@ variable "archive_api_port" {
   default = null
 }
 
+variable "archive_api_url" {
+  type    = string
+  default = null
+}
+
 variable "private_archive_api_gateway" {
   type = bool
   default = true
@@ -264,3 +269,4 @@ variable "bucket_map" {
   type = map(object({ name = string, type = string }))
   default = {}
 }
+


### PR DESCRIPTION
defaults to null but is needed when wanting to deploy dashboard via these instructions

https://nasa.github.io/cumulus/docs/next/operator-docs/serve-dashboard-from-cloudfront
