### PR TITLE
Expose ecs instance type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased changes
+
+### CHANGES
+
+* Expose EC2 instance type for the default Cumulus ECS cluster.  Still deafaults to `t3.medium`.
+  Can be changed via any of the cumulus .tfvars files in CIRRUS-DAAC
+
 ## v1.24.0.0
 
 ### CHANGES

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -14,6 +14,7 @@ module "cumulus" {
   ecs_cluster_min_size            = 1
   ecs_cluster_desired_size        = 1
   ecs_cluster_max_size            = 2
+  ecs_cluster_instance_type       = var.ecs_cluster_instance_type
   key_name                        = var.key_name
 
   urs_url             = var.urs_url

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -270,3 +270,7 @@ variable "bucket_map" {
   default = {}
 }
 
+variable "ecs_cluster_instance_type" {
+  type        = string
+  default     = "t3.medium"
+}


### PR DESCRIPTION
While doing some testing I found the need to change the EC2 instance type for the default Cumulus ECS cluster.  This commit exposes that variable so others can do the same by adding the following variable to any of their cumulus .tfvars files.

`ecs_cluster_instance_type = "your ec2 type"`