### PR TITLE
use latest AMI as default for ecs_cluster_instance_image_id

### DIFF
--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -9,7 +9,7 @@ module "cumulus" {
 
   deploy_to_ngap = true
 
-  ecs_cluster_instance_image_id   = var.ecs_cluster_instance_image_id
+  ecs_cluster_instance_image_id   = "${var.ecs_cluster_instance_image_id != "" ? var.ecs_cluster_instance_image_id : data.aws_ssm_parameter.ecs_image_id.value}"
   ecs_cluster_instance_subnet_ids = data.aws_subnet_ids.subnet_ids.ids
   ecs_cluster_min_size            = 1
   ecs_cluster_desired_size        = 1
@@ -153,6 +153,10 @@ data "terraform_remote_state" "data_persistence" {
 
 data "aws_lambda_function" "sts_credentials" {
   function_name = "gsfc-ngap-sh-s3-sts-get-keys"
+}
+
+data "aws_ssm_parameter" "ecs_image_id" {
+  name = "image_id_ecs_amz2"
 }
 
 resource "aws_security_group" "no_ingress_all_egress" {

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -263,10 +263,10 @@ variable "deploy_distribution_s3_credentials_endpoint" {
 
 variable "ecs_cluster_instance_image_id" {
   type = string
+  default = ""
 }
 
 variable "bucket_map" {
   type = map(object({ name = string, type = string }))
   default = {}
 }
-


### PR DESCRIPTION
* allow overriding in CIRRUS-DAAC

Thanks @bbuechler for the tip on using terraform's ternary!

Related - https://github.com/asfadmin/CIRRUS-DAAC/pull/24