### PR TITLE
Tea bucket map override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+* add optional bucket_map_key variable to allow override of default TEA bucket_map
+
 ## v2.0.1.0
 
 ### CHANGES

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -73,6 +73,7 @@ module "cumulus" {
 
   distribution_url = var.distribution_url
   thin_egress_jwt_secret_name = "${local.prefix}-jwt_secret_for_tea"
+  bucket_map_key = var.bucket_map_key
 
   sts_credentials_lambda_function_arn = data.aws_lambda_function.sts_credentials.arn
 

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -270,3 +270,9 @@ variable "bucket_map" {
   type = map(object({ name = string, type = string }))
   default = {}
 }
+
+variable "bucket_map_key" {
+  description = "Optional S3 Key for TEA bucket map object to override default Cumulus configuration"
+  type        = string
+  default     = null
+}


### PR DESCRIPTION
By default Cumulus generates a TEA bucket_map.  Version 2.0.0 allows an integrator to override the default.  This set of commits exposes the new bucket_map_key variable for use