### PR TITLE
Removing ignore_tags

### DIFF
--- a/cumulus/common.tf
+++ b/cumulus/common.tf
@@ -8,9 +8,7 @@ terraform {
 }
 
 provider "aws" {
-  ignore_tags {
-    key_prefixes = ["gsfc-ngap"]
-  }
+
 }
 
 locals {


### PR DESCRIPTION
Causes this error on deploy:

```
Error: Unsupported block type

  on common.tf line 11, in provider "aws":
  11:   ignore_tags {

Blocks of type "ignore_tags" are not expected here. Did you mean to define
argument "ignore_tags"? If so, use the equals sign to assign it a value.
```
