### PR TITLE
upgrade Cumulus to v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,16 @@
 # CHANGELOG
+
+## v5.0.0.0
+
+* Upgrade to Cumulus [V5.0.0](https://github.com/nasa/Cumulus/releases/tag/v5.0.0)
+* Update includes the addition of the `egress_lambda_log_group` and
+  `egress_lambda_log_subscription_filter` plus the removal of the `tea_stack_name`
+  mentioned in the migration steps
+* Cumulus 5.0.0 requires a one time [reindex](https://nasa.github.io/cumulus-api/#reindex)
+  and [changeindex](https://nasa.github.io/cumulus-api/#change-index)
+* Update adds a `egress_lambda_log_retention_days` variable with a default of 30
+  to allow a DAAC to control the number of days to keep logs.
+
 ## v4.0.0.1
 
 * Upgrade aws terraform provider to 3.19.x and ignore gsfc-ngap tags when deciding what components need to be rebuilt

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v4.0.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v5.0.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
@@ -10,7 +10,7 @@ module "cumulus" {
 
   deploy_to_ngap = true
 
-  ecs_cluster_instance_image_id   = var.ecs_cluster_instance_image_id != "" ? var.ecs_cluster_instance_image_id : data.aws_ssm_parameter.ecs_image_id.value
+  ecs_cluster_instance_image_id = var.ecs_cluster_instance_image_id != "" ? var.ecs_cluster_instance_image_id : data.aws_ssm_parameter.ecs_image_id.value
 
   ecs_cluster_instance_subnet_ids         = data.aws_subnet_ids.subnet_ids.ids
   ecs_cluster_min_size                    = var.ecs_cluster_min_size
@@ -76,9 +76,6 @@ module "cumulus" {
   archive_api_users = var.api_users
   archive_api_url   = var.archive_api_url
 
-  # Thin Egress App settings
-  # must match stack_name variable for thin-egress-app module
-  tea_stack_name = local.tea_stack_name
   # must match stage_name variable for thin-egress-app module
   tea_api_gateway_stage = local.tea_stage_name
 

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -57,3 +57,22 @@ resource "aws_cloudwatch_log_subscription_filter" "egress_api_gateway_log_subscr
   filter_pattern  = ""
   log_group_name  = module.thin_egress_app.egress_log_group
 }
+
+# Egress Lambda Log Group
+resource "aws_cloudwatch_log_group" "egress_lambda_log_group" {
+  count             = (module.thin_egress_app.egress_lambda_name != null && var.log_destination_arn != null) ? 1 : 0
+  name              = "/aws/lambda/${module.thin_egress_app.egress_lambda_name}"
+  retention_in_days = var.egress_lambda_log_retention_days
+  tags              = local.default_tags
+}
+
+# Egress Lambda Log Group Filter
+resource "aws_cloudwatch_log_subscription_filter" "egress_lambda_log_subscription_filter" {
+  count           = (module.thin_egress_app.egress_lambda_name != null && var.log_destination_arn != null) ? 1 : 0
+  depends_on      = [aws_cloudwatch_log_group.egress_lambda_log_group]
+  name            = "${local.prefix}-EgressLambdaLogSubscriptionToSharedDestination"
+  destination_arn = var.log_destination_arn
+  distribution    = "ByLogStream"
+  filter_pattern  = ""
+  log_group_name  = aws_cloudwatch_log_group.egress_lambda_log_group[0].name
+}

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -268,9 +268,9 @@ variable "deploy_distribution_s3_credentials_endpoint" {
 # }
 
 variable "ecs_cluster_instance_image_id" {
-  type    = string
+  type        = string
   description = "AMI ID of ECS instances"
-  default = ""
+  default     = ""
 }
 
 variable "ecs_cluster_instance_type" {
@@ -345,4 +345,10 @@ variable "thin_egress_lambda_code_dependency_archive_key" {
   type        = string
   default     = null
   description = "S3 Key of packaged python modules for lambda dependency layer."
+}
+
+variable "egress_lambda_log_retention_days" {
+  type        = number
+  default     = 30
+  description = "Number of days to retain TEA logs"
 }

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v4.0.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v5.0.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids


### PR DESCRIPTION
Here's a draft of a Cumulus 5.0.0 upgrade.  I have not yet created a script to do the `reindex` and `change index` mentioned in the migration steps.  Do you think we should add such a script to a new `scripts/cumulus5.0.0` directory, or is mentioning  it in the CHANGELOG enough?  