### PR TITLE
update replace_tf_providers.sh, add daac-init and workflows-init make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,14 @@ tf-init:
 	terraform init -reconfigure -input=false -no-color
 	terraform workspace new ${MATURITY} 2>/dev/null || terraform workspace select ${MATURITY}
 
+daac-init:
+	cd ${DAAC_DIR}
+	make $@
+
+workflows-init:
+	cd ${DAAC_DIR}
+	make $@
+
 %-init:
 	$(banner)
 	cd $*

--- a/scripts/cumulus-v5.0.1-tf-upgrade/replace_tf_providers.sh
+++ b/scripts/cumulus-v5.0.1-tf-upgrade/replace_tf_providers.sh
@@ -1,54 +1,50 @@
 #!/usr/bin/env bash
 
-# These commands are necessary to replace the providers, the plan-*** must be
-# run first to download new provider plugins, but it will fail.  Then the
-# replace-provider commands can be run.  Finally re-run the plan and it will
-# succeed
-
 # must be done for each DEPLOY_NAME - MATURITY combo
 
 cd /CIRRUS-core
 
+make tf-init
+
+function replace_providers() {
+    path=${1}
+    module=${2}
+
+    # this will download new provider plugins, but ultimately fail; it runs
+    # `terraform init -reconfigure` and is therefore a prerequisite to the
+    # `terraform state replace-provider` command below
+    make "${module}-init"
+
+    cd "${path}/${module}"
+
+    # replace the providers so the next init/plan will succeed; you can add
+    # additional hashicorp plugins to the PROVIDER list if you use any that are
+    # not listed here
+    #
+    # if nothing in the module uses the given provider, the replace-provider
+    # command will exit without failure and report that there is nothing to
+    # replace, so it's ok to `replace-provider` for providers that aren't
+    # actually used by the module
+    for PROVIDER in aws archive null; do
+        echo "CIRRUS: replacing provider 'registry.terraform.io/-/${PROVIDER}'..."
+        terraform state replace-provider -auto-approve\
+                  registry.terraform.io/-/${PROVIDER} \
+                  registry.terraform.io/hashicorp/${PROVIDER}
+    done
+
+    cd /CIRRUS-core
+}
+
+replace_providers /CIRRUS-DAAC daac
+replace_providers /CIRRUS-core data-persistence
+replace_providers /CIRRUS-core cumulus
+replace_providers /CIRRUS-DAAC workflows
+
+# all plans should work, exit with failure if any do not
+set -e
+cd /CIRRUS-core
 make plan-tf
-
 make plan-daac
-
-cd /CIRRUS-DAAC/daac
-
-terraform state replace-provider -auto-approve registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws
-terraform state replace-provider -auto-approve registry.terraform.io/-/archive registry.terraform.io/hashicorp/archive
-terraform state replace-provider -auto-approve registry.terraform.io/-/null registry.terraform.io/hashicorp/null
-
-cd /CIRRUS-core
-
-make plan-daac
-
 make plan-data-persistence
-
-cd /CIRRUS-core/data-persistence
-
-terraform state replace-provider -auto-approve registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws
-
-cd /CIRRUS-core
-
-make plan-data-persistence
-
 make plan-cumulus
-
-cd /CIRRUS-core/cumulus
-
-terraform state replace-provider -auto-approve registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws
-
-cd /CIRRUS-core
-
-make plan-cumulus
-
-make plan-workflows
-
-cd /CIRRUS-DAAC/workflows
-
-terraform state replace-provider -auto-approve registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws
-
-cd /CIRRUS-core
-
 make plan-workflows


### PR DESCRIPTION
* chmod u+x
* replace initial "plan" with "init"
* move follow-up "plan" to end of script; execute all plans with `set -e` so that
  if any fail, the script will also exit with failure
* added daac-init and workflows-init targets to Makefile
* grouped commands, added module comments
* DRY out replace_tf_providers.sh with a function

We (NSIDC) were successfully able to deploy to SIT using replace_tf_providers.sh in our CI/CD process without any manual terraform commands. cc @michaeljb 