### PR TITLE
cumulus 9.2.0 update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ daac-repo
 daac
 workflows
 .python-version
+data-migration1/terraform.tfvars
+scripts/**/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,54 @@
 # CHANGELOG
 
+## v9.2.0.0
+
+* Upgrade to Cumulus [v9.2.0](https://github.com/nasa/Cumulus/releases/tag/v9.2.0)
+  * Version [v9.0.1](https://github.com/nasa/Cumulus/releases/tag/v9.0.1) has a
+    number of migration instructions detailed
+    [here](https://nasa.github.io/cumulus/docs/upgrade-notes/upgrade-rds)
+  * Per the migration instructions, this version of CIRRUS assumes that the DAACs
+    RDS creation is contained the `rds` directory of that DAACs `CIRRUS-DAAC` code.
+    The datbase is created by running `make rds` with the appropriate parameters.
+    `make plan-rds` can be run to check parameters.
+  * A new `make data-migration1` target has been created and can be used for that
+    step of the migration.  `make plan-data-migration1` can be run to check parameters
+  * Scripts for the migration1 and 2 lambda invokecations can be found in the
+    `scripts/cumulus-v9.2.0` directory
+  * While there are no specific migration instructions, the release notes for
+    Version [v9.1.0](https://github.com/nasa/Cumulus/releases/tag/v9.1.0) should
+    also be reviewed
+  * a serverless RDS requires at least 2 subnets to be defined, CIRRUS had only been
+    using one via commands like this:
+
+```terraform
+data "aws_subnet_ids" "subnet_ids" {
+  vpc_id = data.aws_vpc.application_vpcs.id
+
+  tags = {
+    Name = "Private application ${data.aws_region.current.name}a subnet"
+  }
+}
+```
+
+* subnets are now defined like this throughout CIRRUS:
+
+```terraform
+data "aws_subnet_ids" "subnet_ids" {
+  vpc_id = data.aws_vpc.application_vpcs.id
+
+  filter {
+    name   = "tag:Name"
+    values = ["Private application ${data.aws_region.current.name}a subnet",
+              "Private application ${data.aws_region.current.name}b subnet"]
+  }
+}
+```
+
+* ElasticSearch stacks with mulitiple subnets require at least 2 nodes
+    so the default number was raised to 2
+* If using a serverless RDS make sure to set `rds_connection_heartbeat` to true
+in the cumulus module
+
 ## v8.1.1.0
 
 * Upgrade to Cumulus [v8.1.1](https://github.com/nasa/Cumulus/releases/tag/v8.1.1)

--- a/cumulus/common.tf
+++ b/cumulus/common.tf
@@ -8,6 +8,9 @@ terraform {
       source  = "hashicorp/null"
       version = "~> 2.1"
     }
+    archive = {
+      source = "hashicorp/archive"
+    }
   }
   backend "s3" {
   }
@@ -68,8 +71,10 @@ data "aws_vpc" "application_vpcs" {
 data "aws_subnet_ids" "subnet_ids" {
   vpc_id = data.aws_vpc.application_vpcs.id
 
-  tags = {
-    Name = "Private application ${data.aws_region.current.name}a subnet"
+  filter {
+    name   = "tag:Name"
+    values = ["Private application ${data.aws_region.current.name}a subnet",
+              "Private application ${data.aws_region.current.name}b subnet"]
   }
 }
 

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v8.1.1/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v9.2.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
@@ -21,19 +21,13 @@ module "cumulus" {
 
   key_name = var.key_name
 
+  rds_security_group         = data.terraform_remote_state.data_persistence.outputs.rds_security_group_id
+  rds_user_access_secret_arn = data.terraform_remote_state.data_persistence.outputs.rds_user_access_secret_arn
+  rds_connection_heartbeat   = var.rds_connection_heartbeat
+
   urs_url             = var.urs_url
   urs_client_id       = var.urs_client_id
   urs_client_password = var.urs_client_password
-
-  ems_host              = var.ems_host
-  ems_port              = var.ems_port
-  ems_path              = var.ems_path
-  ems_datasource        = var.ems_datasource
-  ems_private_key       = var.ems_private_key
-  ems_provider          = var.ems_provider
-  ems_retention_in_days = var.ems_retention_in_days
-  ems_submit_report     = var.ems_submit_report
-  ems_username          = var.ems_username
 
   metrics_es_host     = var.metrics_es_host
   metrics_es_username = var.metrics_es_username
@@ -87,7 +81,9 @@ module "cumulus" {
   tea_internal_api_endpoint     = module.thin_egress_app.internal_api_endpoint
   tea_external_api_endpoint     = module.thin_egress_app.api_endpoint
 
-  sts_credentials_lambda_function_arn = data.aws_lambda_function.sts_credentials.arn
+  sts_credentials_lambda_function_arn   = data.aws_lambda_function.sts_credentials.arn
+  sts_policy_helper_lambda_function_arn = data.aws_lambda_function.sts_policy_helper.arn
+  cmr_acl_based_credentials             = var.cmr_acl_based_credentials
 
   archive_api_port            = var.archive_api_port
   private_archive_api_gateway = var.private_archive_api_gateway
@@ -98,13 +94,15 @@ module "cumulus" {
 
   additional_log_groups_to_elk = var.additional_log_groups_to_elk
 
-  ems_deploy = var.ems_deploy
-
   tags = local.default_tags
 }
 
 data "aws_lambda_function" "sts_credentials" {
   function_name = "gsfc-ngap-sh-s3-sts-get-keys"
+}
+
+data "aws_lambda_function" "sts_policy_helper" {
+  function_name = "gsfc-ngap-sh-sts-policy-helper"
 }
 
 data "aws_ssm_parameter" "ecs_image_id" {

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -338,3 +338,15 @@ variable "egress_lambda_log_retention_days" {
   default     = 30
   description = "Number of days to retain TEA logs"
 }
+
+variable "rds_connection_heartbeat" {
+  description = "If true, send a query to verify database connection is live on connection creation and retry on initial connection timeout.  Set to false if not using serverless RDS"
+  type    = bool
+  default = false
+}
+
+variable "cmr_acl_based_credentials" {
+  type = bool
+  default = false
+  description = "Option to enable/disable user based CMR ACLs to derive permission for s3 credential access tokens"
+}

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -1,0 +1,94 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 3.5.0"
+    }
+  }
+  backend "s3" {
+  }
+}
+
+provider "aws" {
+
+  ignore_tags {
+    key_prefixes = ["gsfc-ngap"]
+  }
+
+}
+
+locals {
+
+  prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+
+  default_tags = {
+    Deployment = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+  }
+
+  permissions_boundary_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
+
+  data_persistence_remote_state_config = {
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    key    = "data-persistence/terraform.tfstate"
+    region = data.aws_region.current.name
+  }
+
+  rds_remote_state_config = {
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    key    = "rds/terraform.tfstate"
+    region = data.aws_region.current.name
+  }
+
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+data "terraform_remote_state" "data_persistence" {
+  backend   = "s3"
+  config    = local.data_persistence_remote_state_config
+  workspace = var.DEPLOY_NAME
+}
+
+data "terraform_remote_state" "rds" {
+  backend   = "s3"
+  config    = local.rds_remote_state_config
+  workspace = var.DEPLOY_NAME
+}
+
+module "data_migration1" {
+  source = "https://github.com/nasa/cumulus/releases/download/v9.2.0/terraform-aws-cumulus-data-migrations1.zip"
+
+  prefix = local.prefix
+
+  permissions_boundary_arn = local.permissions_boundary_arn
+
+  vpc_id                   = data.aws_vpc.application_vpcs.id
+  lambda_subnet_ids        = data.aws_subnet_ids.subnet_ids.ids
+
+  dynamo_tables = data.terraform_remote_state.data_persistence.outputs.dynamo_tables
+
+  rds_security_group_id      = data.terraform_remote_state.rds.outputs.rds_security_group_id
+  rds_user_access_secret_arn = data.terraform_remote_state.rds.outputs.rds_user_access_secret_arn
+  rds_connection_heartbeat   = var.rds_connection_heartbeat
+
+  provider_kms_key_id = var.provider_kms_key_id
+
+  tags = merge(var.tags, local.default_tags)
+}
+
+data "aws_vpc" "application_vpcs" {
+  tags = {
+    Name = "Application VPC"
+  }
+}
+
+data "aws_subnet_ids" "subnet_ids" {
+  vpc_id = data.aws_vpc.application_vpcs.id
+
+  filter {
+    name   = "tag:Name"
+    values = ["Private application ${data.aws_region.current.name}a subnet",
+              "Private application ${data.aws_region.current.name}b subnet"]
+  }
+}

--- a/data-migration1/variables.tf
+++ b/data-migration1/variables.tf
@@ -1,0 +1,53 @@
+variable "DEPLOY_NAME" {
+  type = string
+}
+
+variable "MATURITY" {
+  type = string
+  default = "dev"
+}
+
+variable "provider_kms_key_id" {
+  type = string
+}
+
+# Optional
+
+variable "lambda_subnet_ids" {
+  type = list(string)
+  default = []
+}
+
+variable "permissions_boundary_arn" {
+  type    = string
+  default = null
+}
+
+variable "rds_connection_heartbeat" {
+  description = "If true, send a query to verify database connection is live on connection creation and retry on initial connection timeout.  Set to false if not using serverless RDS"
+  type    = bool
+  default = true
+}
+
+variable "rds_security_group_id" {
+  description = "RDS Security Group used for access to RDS cluster"
+  type        = string
+  default     = ""
+}
+
+variable "region" {
+  type    = string
+  default = "us-west-2"
+}
+
+variable "tags" {
+  description = "Tags to be applied to Cumulus resources that support tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "vpc_id" {
+  type    = string
+  default = null
+}
+

--- a/data-migration1/versions.tf
+++ b/data-migration1/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v8.1.1/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v9.2.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids
@@ -28,12 +28,32 @@ module "data_persistence" {
 
   elasticsearch_config = var.elasticsearch_config
 
+  vpc_id                     = data.aws_vpc.application_vpcs.id
+  permissions_boundary_arn   = local.permissions_boundary_arn
+  rds_user_access_secret_arn = data.terraform_remote_state.rds.outputs.rds_user_access_secret_arn
+  rds_security_group_id      = data.terraform_remote_state.rds.outputs.rds_security_group_id
+
+  tags = local.default_tags
 }
 
 locals {
   prefix = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+
+  default_tags = {
+    Deployment = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
+  }
+
+  permissions_boundary_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/NGAPShRoleBoundary"
+
+  rds_remote_state_config = {
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    key    = "rds/terraform.tfstate"
+    region = data.aws_region.current.name
+  }
+
 }
 
+data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
 data "aws_vpc" "application_vpcs" {
@@ -45,7 +65,15 @@ data "aws_vpc" "application_vpcs" {
 data "aws_subnet_ids" "subnet_ids" {
   vpc_id = data.aws_vpc.application_vpcs.id
 
-  tags = {
-    Name = "Private application ${data.aws_region.current.name}a subnet"
+  filter {
+    name   = "tag:Name"
+    values = ["Private application ${data.aws_region.current.name}a subnet",
+              "Private application ${data.aws_region.current.name}b subnet"]
   }
+}
+
+data "terraform_remote_state" "rds" {
+  backend   = "s3"
+  workspace = var.DEPLOY_NAME
+  config    = local.rds_remote_state_config
 }

--- a/data-persistence/outputs.tf
+++ b/data-persistence/outputs.tf
@@ -17,3 +17,11 @@ output "elasticsearch_security_group_id" {
 output "elasticsearch_alarms" {
   value = module.data_persistence.elasticsearch_alarms
 }
+
+output "rds_security_group_id" {
+  value = data.terraform_remote_state.rds.outputs.rds_security_group_id
+}
+
+output "rds_user_access_secret_arn" {
+  value = data.terraform_remote_state.rds.outputs.rds_user_access_secret_arn
+}

--- a/data-persistence/variables.tf
+++ b/data-persistence/variables.tf
@@ -23,7 +23,7 @@ variable "elasticsearch_config" {
   })
   default = {
     domain_name    = "es"
-    instance_count = 1
+    instance_count = 2
     instance_type  = "t2.small.elasticsearch"
     version        = "5.3"
     volume_size    = 10

--- a/scripts/cumulus-v9.2.0/data_migration1.sh
+++ b/scripts/cumulus-v9.2.0/data_migration1.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+# run this lambda after deploying the data_migration1 module
+
+aws lambda invoke --function-name $DEPLOY_NAME-cumulus-$MATURITY-data-migration1 $DEPLOY_NAME-cumulus-$MATURITY-dm1.log

--- a/scripts/cumulus-v9.2.0/data_migration2.sh
+++ b/scripts/cumulus-v9.2.0/data_migration2.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# run this lambda after deploying the cumulus module
+
+PAYLOAD=$(echo '{"executionMigrationParams": { "parallelScanSegments": 50, "writeConcurrency": 50 }}')
+
+aws lambda invoke --function-name $DEPLOY_NAME-cumulus-$MATURITY-postgres-migration-async-operation \
+  --payload "$PAYLOAD" $DEPLOY_NAME-cumulus-$MATURITY-dm2.log


### PR DESCRIPTION
I have successfully upgraded a couple Cumulus instances with this code.  It pretty tightly couples the RDS creation with the rest of cumulus by using `rds` terraform_remote_state variables inside of the data-persistence module.  This can easily be refactored to use passed in variables instead.  Let me know what you think.

