### PR TITLE
upgrade Cumulus to v9.7.0 and TEA to build 115

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## v9.7.0.0
 
 * Upgrade to Cumulus [v9.7.0](https://github.com/nasa/Cumulus/releases/tag/v9.7.0)
-* remove rds_connection_heartbeat variable due to change in Cumulus [v9.3.0](https://github.com/nasa/Cumulus/releases/tag/v9.3.0)
+* remove rds_connection_heartbeat variable due to change in Cumulus [v9.3.0](https://github.com/nasa/cumulus/blob/master/CHANGELOG.md#v930-2021-07-26)
 * add timeout variables introduced in Cumulus [v9.5.0](https://github.com/nasa/Cumulus/releases/tag/v9.5.0)
 to allow CIRRUS users to customize Lambda timeouts.  Usage is documented
 [here](https://nasa.github.io/cumulus/docs/configuration/ingest-task-configuration#lambda_timeouts)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
 # CHANGELOG
 
+## v9.7.0.0
+
+* Upgrade to Cumulus [v9.7.0](https://github.com/nasa/Cumulus/releases/tag/v9.7.0)
+* remove rds_connection_heartbeat variable due to change in Cumulus [v9.3.0](https://github.com/nasa/Cumulus/releases/tag/v9.3.0)
+* add timeout variables introduced in Cumulus [v9.5.0](https://github.com/nasa/Cumulus/releases/tag/v9.5.0)
+to allow CIRRUS users to customize Lambda timeouts.  Usage is documented
+[here](https://nasa.github.io/cumulus/docs/configuration/ingest-task-configuration#lambda_timeouts)
+* Upgrade TEA to build [115](https://github.com/asfadmin/thin-egress-app/releases/tag/tea-build.115)
+to add Smarter In-Region control and Dynamic CORS Support plus CVE Remediation.
+As described in the release notes, it requires two migration steps to rebuild an IAM
+role and flush the IAM cache.  These commands are in [scripts/tea-115/iam_update_and_cache_clear.sh](./scripts/tea-115/iam_update_and_cache_clear.sh)
+* add `use_cors` variable to allow CIRRUS users to use this new feature of TEA
+* REMINDER: This release requires [v7.0.0 of the Cumulus Dashboard](https://github.com/nasa/cumulus-dashboard/releases/tag/v7.0.0)
+
 ## v9.2.0.2
 
-* Add a throttled queue to the cumulus deployment per the 
+* Add a throttled queue to the cumulus deployment per the
 [data cookbook instructions](https://nasa.github.io/cumulus/docs/next/data-cookbooks/throttling-queued-executions).
-The number of concurrent executions defaults to 5 and can be overriden via a `thottled_queue_execution_limit` 
+The number of concurrent executions defaults to 5 and can be overriden via a `thottled_queue_execution_limit`
 variable in the appropriate CIRRUS-DAAC/cumulus/env.tfvars file
 * Added a `destroy-data-persistence` target to the Makefile borrowing heavily from NSIDC's instructions for [destroying the
 dynamo_db tables](scripts/destroy-dp-dynamo-tables.sh)  Since the script exits as soon as the tables are marked for

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v9.2.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v9.7.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
@@ -23,7 +23,6 @@ module "cumulus" {
 
   rds_security_group         = data.terraform_remote_state.data_persistence.outputs.rds_security_group_id
   rds_user_access_secret_arn = data.terraform_remote_state.data_persistence.outputs.rds_user_access_secret_arn
-  rds_connection_heartbeat   = var.rds_connection_heartbeat
 
   urs_url             = var.urs_url
   urs_client_id       = var.urs_client_id
@@ -43,6 +42,8 @@ module "cumulus" {
   cmr_provider    = var.cmr_provider
 
   cmr_oauth_provider = var.cmr_oauth_provider
+
+  lambda_timeouts = var.lambda_timeouts
 
   launchpad_api         = var.launchpad_api
   launchpad_certificate = var.launchpad_certificate

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -1,5 +1,5 @@
 module "thin_egress_app" {
-  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.111.zip"
+  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.115.zip"
 
   auth_base_url                      = var.urs_url
   bucket_map_file                    = local.bucket_map_key == null ? aws_s3_bucket_object.bucket_map_yaml.id : local.bucket_map_key
@@ -18,6 +18,7 @@ module "thin_egress_app" {
   stack_name                         = local.tea_stack_name
   stage_name                         = local.tea_stage_name
   urs_auth_creds_secret_name         = aws_secretsmanager_secret.thin_egress_urs_creds.name
+  use_cors                           = var.use_cors
   vpc_subnet_ids                     = data.aws_subnet_ids.subnet_ids.ids
 }
 

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -339,12 +339,6 @@ variable "egress_lambda_log_retention_days" {
   description = "Number of days to retain TEA logs"
 }
 
-variable "rds_connection_heartbeat" {
-  description = "If true, send a query to verify database connection is live on connection creation and retry on initial connection timeout.  Set to false if not using serverless RDS"
-  type        = bool
-  default     = false
-}
-
 variable "cmr_acl_based_credentials" {
   type        = bool
   default     = false
@@ -355,4 +349,16 @@ variable "thottled_queue_execution_limit" {
   type        = number
   description = "Cumulus Throttled Queue execution limit"
   default     = 5
+}
+
+variable "lambda_timeouts" {
+  description = "Configurable map of timeouts for ingest task lambdas in the form <lambda_identifier>_timeout: <timeout>"
+  type        = map(string)
+  default     = {}
+}
+
+variable "use_cors" {
+  type        = bool
+  default     = false
+  description = "Enable cross origin resource sharing"
 }

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -57,14 +57,14 @@ data "terraform_remote_state" "rds" {
 }
 
 module "data_migration1" {
-  source = "https://github.com/nasa/cumulus/releases/download/v9.2.0/terraform-aws-cumulus-data-migrations1.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v9.7.0/terraform-aws-cumulus-data-migrations1.zip"
 
   prefix = local.prefix
 
   permissions_boundary_arn = local.permissions_boundary_arn
 
-  vpc_id                   = data.aws_vpc.application_vpcs.id
-  lambda_subnet_ids        = data.aws_subnet_ids.subnet_ids.ids
+  vpc_id            = data.aws_vpc.application_vpcs.id
+  lambda_subnet_ids = data.aws_subnet_ids.subnet_ids.ids
 
   dynamo_tables = data.terraform_remote_state.data_persistence.outputs.dynamo_tables
 
@@ -87,8 +87,8 @@ data "aws_subnet_ids" "subnet_ids" {
   vpc_id = data.aws_vpc.application_vpcs.id
 
   filter {
-    name   = "tag:Name"
+    name = "tag:Name"
     values = ["Private application ${data.aws_region.current.name}a subnet",
-              "Private application ${data.aws_region.current.name}b subnet"]
+    "Private application ${data.aws_region.current.name}b subnet"]
   }
 }

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v9.2.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v9.7.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids
@@ -66,9 +66,9 @@ data "aws_subnet_ids" "subnet_ids" {
   vpc_id = data.aws_vpc.application_vpcs.id
 
   filter {
-    name   = "tag:Name"
+    name = "tag:Name"
     values = ["Private application ${data.aws_region.current.name}a subnet",
-              "Private application ${data.aws_region.current.name}b subnet"]
+    "Private application ${data.aws_region.current.name}b subnet"]
   }
 }
 

--- a/scripts/tea-115/iam_update_and_cache_clear.sh
+++ b/scripts/tea-115/iam_update_and_cache_clear.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+aws --region=us-west-2 --profile=${AWS_PROFILE} lambda invoke \
+    --function-name ${DEPLOY_NAME}-cumulus-${MATURITY}-thin-egress-app-UpdatePolicyLambda \
+    --payload "{}" -
+
+aws --region=us-west-2 --profile=${AWS_PROFILE} lambda invoke \
+    --function-name ${DEPLOY_NAME}-cumulus-${MATURITY}-thin-egress-app-BumperLambda --payload "{}" - 


### PR DESCRIPTION
Initial PR for testing

# CHANGELOG

* Upgrade to Cumulus [v9.7.0](https://github.com/nasa/Cumulus/releases/tag/v9.7.0)
* remove rds_connection_heartbeat variable due to change in Cumulus [v9.3.0](https://github.com/nasa/cumulus/blob/master/CHANGELOG.md#v930-2021-07-26)
* add timeout variables introduced in Cumulus [v9.5.0](https://github.com/nasa/Cumulus/releases/tag/v9.5.0)
to allow CIRRUS users to customize Lambda timeouts.  Usage is documented
[here](https://nasa.github.io/cumulus/docs/configuration/ingest-task-configuration#lambda_timeouts)
* Upgrade TEA to build [115](https://github.com/asfadmin/thin-egress-app/releases/tag/tea-build.115)
to add Smarter In-Region control and Dynamic CORS Support plus CVE Remediation.
As described in the release notes, it requires two migration steps to rebuild an IAM
role and flush the IAM cache.  These commands are in [scripts/tea-115/iam_update_and_cache_clear.sh](./scripts/tea-115/iam_update_and_cache_clear.sh)
* add `use_cors` variable to allow CIRRUS users to use this new feature of TEA
* REMINDER: This release requires [v7.0.0 of the Cumulus Dashboard](https://github.com/nasa/cumulus-dashboard/releases/tag/v7.0.0)
