### PR TITLE
GitHub Actions: run just for master and PRs, only on Linux

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - main
   pull_request:
 
 jobs:


### PR DESCRIPTION
NSIDC recently got an alert that we were at 75% of our GitHub Action minutes limit for the month, and then we found that Windows build minutes count for 2x, and Mac build minutes count for 10x. The lint config added in https://github.com/asfadmin/CIRRUS-core/pull/121 was copy-pasted from a template that ran on Linux, Windows, and Mac, but running on Linux should be all that's necessary and should cut down on ASF's GitHub Actions usage (I've already applied this change on NSIDC's fork).

Additionally, the linting doesn't need to run on tags or on open branches that are not in pull requests, so the configuration is set to run only for the `master` branch and pull requests.

See also https://github.com/asfadmin/CIRRUS-DAAC/pull/62