### PR TITLE
Jenkins / Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,12 +72,10 @@ tf-init:
 	terraform workspace new ${MATURITY} 2>/dev/null || terraform workspace select ${MATURITY}
 
 daac-init:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 workflows-init:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 %-init:
 	$(banner)
@@ -117,25 +115,20 @@ plan-tf: tf-init
 
 # ---------------------------
 daac:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 plan-daac:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 # ---------------------------
 rds:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 plan-rds:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 destroy-rds:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 # ---------------------------
 data-migration1: data-migration1-init
@@ -323,26 +316,23 @@ destroy-cumulus: cumulus-init
 
 # ---------------------------
 workflows:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 plan-workflows:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 destroy-workflows:
-	cd ${DAAC_DIR}
-	make $@
+	$(MAKE) -C ${DAAC_DIR} $@
 
 # ---------------------------
 cumulus_v9_2_0_upgrade:
-	make rds
-	make data-persistence
-	make data-migration1
+	$(MAKE) rds
+	$(MAKE) data-persistence
+	$(MAKE) data-migration1
 	bash /CIRRUS-core/scripts/cumulus-v9.2.0/data_migration1.sh
-	make cumulus
+	$(MAKE) cumulus
 	bash /CIRRUS-core/scripts/cumulus-v9.2.0/data_migration2.sh
-	make workflows
+	$(MAKE) workflows
 
 # ---------------------------
 all: \

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -79,7 +79,7 @@ pipeline {
         CMR_CREDS = credentials("${params.CMR_CREDS_ID}")
         URS_CREDS = credentials("${params.URS_CREDS_ID}")
         TOKEN_SECRET = credentials("${params.SECRET_TOKEN_ID}")
-        MAKE_COMMAND = "${params.MAKE_COMMAND}"
+        MAKE_TARGET = "${params.MAKE_COMMAND}"
         BUILD_NUM = "${env.BUILD_NUMBER}"/**/
       }
       steps {
@@ -106,7 +106,7 @@ pipeline {
                                     -v "${WORKSPACE}/daac-repo":/daac-repo \
                                     --name=cirrus-core \
                                     cirrus-core \
-                                    /bin/bash -c "make $MAKE_COMMAND"
+                                    /bin/bash -c "make $MAKE_TARGET"
             '''
 
         }// withCredentials

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -101,7 +101,6 @@ pipeline {
                                     --env TF_VAR_urs_client_id="${URS_CREDS_USR}" \
                                     --env TF_VAR_urs_client_password="${URS_CREDS_PSW}" \
                                     --env TF_VAR_token_secret="${TOKEN_SECRET}" \
-                                    --env MAKE_COMMAND="${MAKE_COMMAND}" \
                                     --env TF_VAR_db_admin_password="${DB_ADMIN_PASSWORD}" \
                                     -v "${WORKSPACE}":/CIRRUS-core \
                                     -v "${WORKSPACE}/daac-repo":/daac-repo \


### PR DESCRIPTION
I ran into a strange bug when refactoring our makefile in CIRRUS-ASF. In Make there is a special variable called `$(MAKE)` that you're supposed to use when calling make from within a makefile so that various options are passed along correctly. However, it turns out that this special variable uses another special variable under the hood called `MAKE_COMMAND` and here in the CIRRUS-core Jenkinsfile we are overriding that variable with the name of the target we want to build. This was giving us the following error:

```
/bin/sh: line 10: all: command not found
```
because `$(MAKE)` actually tries to execute `$(MAKE_COMMAND)` as a shell command and we were setting that value to `all` in the environment variables.

I was able to get the pipeline to work by renaming the environment variable to `MAKE_TARGET` which doesn't collide with the builtin variable, and I actually removed the `--env` option for it from the docker run command since it wasn't being used anywhere in any of the makefiles anyways. I also went ahead and replaced the recursive invocations of make in the main makefile with the recommended way of using `$(MAKE) -C directory` so that make flags will be propagated correctly.