### PR TITLE
Add version tag to cirrus-core image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@
 #  MATURITY:              One of: DEV, INT, TEST, PROD
 
 # ---------------------------
+DOCKER_TAG := v11.1.0.1
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}
@@ -49,7 +50,7 @@ endef
 
 # ---------------------------
 image: Dockerfile
-	docker build -f Dockerfile --no-cache -t cirrus-core .
+	docker build -f Dockerfile --no-cache -t cirrus-core:$(DOCKER_TAG) .
 
 container-shell:
 	docker run -it --rm \
@@ -60,7 +61,7 @@ container-shell:
 		-v ${DAAC_DIR}:/CIRRUS-DAAC \
 		-v ${HOME}/.aws:/.aws \
 		--name=cirrus-core \
-		cirrus-core \
+		cirrus-core:$(DOCKER_TAG) \
 		bash
 
 # ---------------------------


### PR DESCRIPTION
This would let you switch between different versions without needing to rebuild the docker image each time. It might even make sense to remove the `--no-cache` argument to avoid redoing a bunch of work when nothing changed.