### PR TITLE
Image shell improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ workflows
 .python-version
 data-migration1/terraform.tfvars
 scripts/**/*.log
+.container_bash_history

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ container-shell:
 		--user `id -u` \
 		--env DAAC_DIR="/CIRRUS-DAAC" \
 		--env AWS_CONFIG_DIR="/" \
+		--env PS1='\s-\v:\w\$$ ' \
+		--env HISTFILE="/CIRRUS-core/.container_bash_history" \
 		-v ${PWD}:/CIRRUS-core \
 		-v ${DAAC_DIR}:/CIRRUS-DAAC \
 		-v ${HOME}/.aws:/.aws \

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,7 @@ container-shell:
 		-v ${PWD}:/CIRRUS-core \
 		-v ${DAAC_DIR}:/CIRRUS-DAAC \
 		-v ${HOME}/.aws:/.aws \
+		-v ${HOME}/.cache/pip:/.cache/pip \
 		--name=cirrus-core \
 		cirrus-core \
 		bash


### PR DESCRIPTION
Some quality of life things I set up for myself when working in a container on my local machine. This saves bash history between restarts of the container and hooks in the pip cache folder to prevent unneeded downloads.