### PR TITLE
upgrade aws cli to V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * Upgrade container packages
   * Upgrade node to 14.x
   * Add C++ compiler
-* 
+  * upgrade AWS CLI to V2
+  * add `PREFIX` env variable as output from env.sh
 * Add a catchall target to the Makefile for forwarding unknown commands. For
   instance running `make foo` from CIRRUS-core will attempt to call `make foo`
   on CIRRUS-DAAC instead of erroring out immediately.

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,12 +29,14 @@ RUN \
 
 # AWS & Terraform
 RUN \
-        yum install -y awscli && \
         python3 -m pip install boto3 && \
         wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
         unzip *.zip && \
         chmod +x terraform && \
-        mv terraform /usr/local/bin
+        mv terraform /usr/local/bin && \
+        curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \
+        unzip awscliv2.zip && \
+        ./aws/install
 
 # SSM SessionManager plugin
 RUN \

--- a/env.sh
+++ b/env.sh
@@ -18,6 +18,7 @@ else
     export AWS_ACCOUNT_ID_LAST4
     export DEPLOY_NAME=$2
     export MATURITY=$3
+    export PREFIX=$DEPLOY_NAME-cumulus-$MATURITY
 
     echo "CIRRUS environment:"
     echo "  AWS_PROFILE:          $AWS_PROFILE"
@@ -26,4 +27,5 @@ else
     echo "  AWS_ACCOUNT_ID_LAST4: $AWS_ACCOUNT_ID_LAST4"
     echo "  DEPLOY_NAME:          $DEPLOY_NAME"
     echo "  MATURITY:             $MATURITY"
+    echo "  PREFIX:               $PREFIX"
 fi


### PR DESCRIPTION
Hi, since the data migration examples we get from the Cumulus team assume we are running AWS CLI V2, I thought it time to upgrade our docker container to use that version.

I'm thinking these last set of changes might be good to group into an CIRRUS 11.1.0.2 release, then we'll be all set for doing the next needed Cumulus upgrade.

I'd be glad to make one more change to the Changelog to add all the changes to a release.  Thoughts?