### PR TITLE
upgrade Cumulus to v11.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
-## Unreleased
+## v11.1.3.0
+
+* Upgrade to [Cumulus v11.1.3](https://github.com/nasa/Cumulus/releases/tag/v11.1.3)
 
 ## v11.1.0.2
 

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 #  MATURITY:              One of: DEV, INT, TEST, PROD
 
 # ---------------------------
-DOCKER_TAG := v11.1.0.1
+DOCKER_TAG := v11.1.3.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v11.1.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v11.1.3/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -57,7 +57,7 @@ data "terraform_remote_state" "rds" {
 }
 
 module "data_migration1" {
-  source = "https://github.com/nasa/cumulus/releases/download/v11.1.0/terraform-aws-cumulus-data-migrations1.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v11.1.3/terraform-aws-cumulus-data-migrations1.zip"
 
   prefix = local.prefix
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v11.1.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v11.1.3/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids


### PR DESCRIPTION
NSIDC needs a bug fix from Cumulus 11.1.3 so creating a CIRRUS release for that version.