### PR TITLE
updates for Cumulus 11.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v11.1.4.0
+
+* Upgrade to [Cumulus v11.1.4](https://github.com/nasa/Cumulus/releases/tag/v11.1.4)
+* Note instructions for creating the `files_granule_cumulus_id_index` in the release
+notes if you are continually ingesting data
+
 ## v11.1.3.0
 
 * Upgrade to [Cumulus v11.1.3](https://github.com/nasa/Cumulus/releases/tag/v11.1.3)

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@
 #  MATURITY:              One of: DEV, INT, TEST, PROD
 
 # ---------------------------
-DOCKER_TAG := v11.1.3.0
+DOCKER_TAG := v11.1.4.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v11.1.3/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v11.1.4/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -57,7 +57,7 @@ data "terraform_remote_state" "rds" {
 }
 
 module "data_migration1" {
-  source = "https://github.com/nasa/cumulus/releases/download/v11.1.3/terraform-aws-cumulus-data-migrations1.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v11.1.4/terraform-aws-cumulus-data-migrations1.zip"
 
   prefix = local.prefix
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v11.1.3/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v11.1.4/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids


### PR DESCRIPTION
I tested this upgrade on both an 11.1.0 instance of cumulus (with the `files_granule_cumulus_id_index` already in place) and an 11.1.3 instance (without the `files_granule_cumulus_id_index` index).  Both seemed work work fine.  The index existed after both installs as expected.  