### PR TITLE
update Cumulus to v14.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ to match those in the underlying Cumulus modules.
 [Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)
 * Also, any ECS tasks are required to use the `cumuluss/cumulus-ecs-task:1.8.0`
 docker image.  This requirement is listed in the
-[Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
+[Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v11.1.8)
 breaking changes section.
 
 ## v13.3.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # CHANGELOG
 
+## v14.1.0.0
+
+* Upgrade to [Cumulus v14.1.0](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
+* Exposes the new `cloudwatch_log_retention_periods` as mentioned in the release
+notes in case a DAAC wants to modify the retention of any CloudWatch log groups.
+* updated the terraform `aws` provider in the `cumulus` and `data-persistence` modules
+to match those in the underlying Cumulus modules.
+* **Reminder** - this version requires
+[Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)
+* Also, any ECS tasks are required to use the `cumuluss/cumulus-ecs-task:1.8.0`
+docker image.  This requirement is listed in the
+[Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
+breaking changes section.
+
 ## v13.3.2.0
 
 * Upgrade to [Cumulus v13.3.2](https://github.com/nasa/Cumulus/releases/tag/v13.3.2)

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #  PYTHON_VER: 			  python3 or python38 which sets the build target in make file
 
 # ---------------------------
-DOCKER_TAG := v13.3.2.0
+DOCKER_TAG := v14.1.0.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/cumulus/common.tf
+++ b/cumulus/common.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70.0"
+      version = "~> 3.0,!= 3.14.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v13.3.2/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
@@ -94,6 +94,8 @@ module "cumulus" {
   deploy_distribution_s3_credentials_endpoint = var.deploy_distribution_s3_credentials_endpoint
 
   additional_log_groups_to_elk = var.additional_log_groups_to_elk
+
+  cloudwatch_log_retention_periods = var.cloudwatch_log_retention_periods
 
   throttled_queues = [{
     url             = aws_sqs_queue.background_job_queue.id,

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -362,3 +362,9 @@ variable "use_cors" {
   default     = false
   description = "Enable cross origin resource sharing"
 }
+
+variable "cloudwatch_log_retention_periods" {
+  type        = map(number)
+  description = "number of days logs will be retained for the respective cloudwatch log group, in the form of <module>_<cloudwatch_log_group_name>_log_retention"
+  default     = {}
+}

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -57,7 +57,7 @@ data "terraform_remote_state" "rds" {
 }
 
 module "data_migration1" {
-  source = "https://github.com/nasa/cumulus/releases/download/v13.3.2/terraform-aws-cumulus-data-migrations1.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-data-migrations1.zip"
 
   prefix = local.prefix
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70.0"
+      version = "~> 3.0,!= 3.14.0"
     }
     null = {
       source  = "hashicorp/null"
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v13.3.2/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids


### PR DESCRIPTION
## v14.1.0.0

* Upgrade to [Cumulus v14.1.0](https://github.com/nasa/Cumulus/releases/tag/v14.1.0)
* Exposes the new `cloudwatch_log_retention_periods` as mentioned in the release notes in case a DAAC wants to modify the retention of any CloudWatch log groups.
* updated the terraform `aws` provider in the `cumulus` and `data-persistence` modules to match those in the underlying Cumulus modules.
* **Reminder** - this version requires [Cumulus Dashboard v12.0.0](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.0)
* Also, any ECS tasks are required to use the `cumuluss/cumulus-ecs-task:1.8.0` docker image.  This requirement is listed in the [Cumulus v11.1.8](https://github.com/nasa/Cumulus/releases/tag/v14.1.0) breaking changes section.
