### PR TITLE
Add name and tags to event rule

### DIFF
--- a/cumulus/throttled-queue.tf
+++ b/cumulus/throttled-queue.tf
@@ -6,7 +6,9 @@ resource "aws_sqs_queue" "background_job_queue" {
 }
 
 resource "aws_cloudwatch_event_rule" "background_job_queue_watcher" {
+  name                = "${local.prefix}-background_job_queue_watcher"
   schedule_expression = "rate(1 minute)"
+  tags                = local.default_tags
 }
 
 resource "aws_cloudwatch_event_target" "background_job_queue_watcher" {


### PR DESCRIPTION
This event rule is unnamed and untagged making it very hard to find as it won't show up when you filter by your stack prefix or search for tagged resources.