### PR TITLE
upgrade Cumulus to v15.0.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ workflows
 data-migration1/terraform.tfvars
 scripts/**/*.log
 .container_bash_history
+.venv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## v15.0.3.0
+
+* Upgrade to [Cumulus v15.0.3](https://github.com/nasa/Cumulus/releases/tag/v15.0.3)
+* Per [Cumulus v15.0.2](https://github.com/nasa/Cumulus/releases/tag/v15.0.2)
+release notes, the new `default_log_retention_days` variable has been exposed in
+the Cumulus module to allow daac customization,  default is 30 days (the release
+notes name it incorrectly)
+* Per [Cumulus v15.0.0](https://github.com/nasa/Cumulus/releases/tag/v15.0.0)
+release notes, all ECS tasks should be upgraded to use the `1.9.0` image
+* Upgraded the terraform aws version to `>= 3.75.2` to support `nodejs16.x` Lambdas
+
 ## v14.1.0.1
 
 * Upgrade to [TEA Release 1.3.2](https://github.com/asfadmin/thin-egress-app/releases/tag/tea-release.1.3.2) which

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #  PYTHON_VER: 			  python3 or python38 which sets the build target in make file
 
 # ---------------------------
-DOCKER_TAG := v14.1.0.0
+DOCKER_TAG := v15.0.3.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/cumulus/common.tf
+++ b/cumulus/common.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0,!= 3.14.0"
+      version = ">= 3.75.2"
     }
     null = {
       source  = "hashicorp/null"

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 
@@ -96,6 +96,7 @@ module "cumulus" {
   additional_log_groups_to_elk = var.additional_log_groups_to_elk
 
   cloudwatch_log_retention_periods = var.cloudwatch_log_retention_periods
+  default_log_retention_days       = var.default_log_retention_days
 
   throttled_queues = [{
     url             = aws_sqs_queue.background_job_queue.id,

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -369,6 +369,12 @@ variable "cloudwatch_log_retention_periods" {
   default     = {}
 }
 
+variable "default_log_retention_days" {
+  type = number
+  default = 30
+  description = "Optional default value that user chooses for their log retention periods"
+}
+
 variable "s3credentials_endpoint" {
   type        = bool
   default     = false

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -57,7 +57,7 @@ data "terraform_remote_state" "rds" {
 }
 
 module "data_migration1" {
-  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus-data-migrations1.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus-data-migrations1.zip"
 
   prefix = local.prefix
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0,!= 3.14.0"
+      version = ">= 3.75.2"
     }
     null = {
       source  = "hashicorp/null"
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v14.1.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.70.0"
+      version = ">= 3.75.2"
     }
   }
 }


### PR DESCRIPTION
* Upgrade to [Cumulus v15.0.3](https://github.com/nasa/Cumulus/releases/tag/v15.0.3)
* Per [Cumulus v15.0.2](https://github.com/nasa/Cumulus/releases/tag/v15.0.2) release notes, the new `default_log_retention_days` variable has been exposed in the Cumulus module to allow daac customization,  default is 30 days (the release notes name it incorrectly)
* Per [Cumulus v15.0.0](https://github.com/nasa/Cumulus/releases/tag/v15.0.0) release notes, all ECS tasks should be upgraded to use the `1.9.0` image
* Upgraded the terraform aws version to `>= 3.75.2` to support `nodejs16.x` Lambdas
