### PR TITLE
Add variable for lambda memory sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v15.0.3.1
+
+* Add `lambda_memory_sizes` to cumulus module variables
+
 ## v15.0.3.0
 
 * Upgrade to [Cumulus v15.0.3](https://github.com/nasa/Cumulus/releases/tag/v15.0.3)

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -43,7 +43,8 @@ module "cumulus" {
 
   cmr_oauth_provider = var.cmr_oauth_provider
 
-  lambda_timeouts = var.lambda_timeouts
+  lambda_memory_sizes = var.lambda_memory_sizes
+  lambda_timeouts     = var.lambda_timeouts
 
   launchpad_api         = var.launchpad_api
   launchpad_certificate = var.launchpad_certificate

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -351,6 +351,12 @@ variable "thottled_queue_execution_limit" {
   default     = 5
 }
 
+variable "lambda_memory_sizes" {
+  description = "Memory sizes for lambda functions"
+  type = map(string)
+  default = {}
+}
+
 variable "lambda_timeouts" {
   description = "Configurable map of timeouts for ingest task lambdas in the form <lambda_identifier>_timeout: <timeout>"
   type        = map(string)


### PR DESCRIPTION
Per the cumulus examples and docs this should be added so we can control the memory sizes of the cumulus tasks. 
https://github.com/nasa/cumulus/blob/master/example/cumulus-tf/variables.tf#L414