### PR TITLE
Add lzards support to cirrus-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## Unreleased
+
+* Add 'lzards' support to cumulus module
+
 ## v15.0.3.1
 
 * Add `lambda_memory_sizes` to cumulus module variables

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -50,6 +50,12 @@ module "cumulus" {
   launchpad_certificate = var.launchpad_certificate
   launchpad_passphrase  = var.launchpad_passphrase
 
+  lzards_launchpad_certificate = var.lzards_launchpad_certificate
+  lzards_launchpad_passphrase  = var.lzards_launchpad_passphrase
+  lzards_provider              = var.lzards_provider
+  lzards_api                   = var.lzards_api
+  lzards_s3_link_timeout       = var.lzards_s3_link_timeout
+
   oauth_provider   = var.oauth_provider
   oauth_user_group = var.oauth_user_group
 

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -44,6 +44,36 @@ variable "launchpad_passphrase" {
   default = ""
 }
 
+variable "lzards_launchpad_certificate" {
+  description = "Name of the Launchpad certificate uploaded to the 'crypto' directory of the `system_bucket` for use with the lzards-backup task`."
+  type        = string
+  default     = "lzards_launchpad.pfx"
+}
+
+variable "lzards_launchpad_passphrase" {
+  description = "Passphrase for use with lzards_launchpad_certificate."
+  type        = string
+  default     = ""
+}
+
+variable "lzards_provider" {
+  description = "LZARDS provider name"
+  type        = string
+  default     = ""
+}
+
+variable "lzards_api" {
+  description = "LZARDS backup API endpoint"
+  type = string
+  default = ""
+}
+
+variable "lzards_s3_link_timeout" {
+  description = "LZARDS S3 access link timeout (seconds)"
+  type        = string
+  default     = ""
+}
+
 variable "oauth_provider" {
   type    = string
   default = "earthdata"


### PR DESCRIPTION
ASF is going to need this in the coming PI. I am able to deploy this without issue but I can not test the lzards cumulus tasks yet because there is a few NAMS that have to be completed so that lzards can use the data. I set it as unreleased for now incase there are other potential changes coming. 