### PR TITLE
upgrade TEA to 1.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # CHANGELOG
 
-## Unreleased
+## v15.0.3.2
 
 * Add 'lzards' support to cumulus module
+* Upgrade to [TEA Release 1.3.3](https://github.com/asfadmin/thin-egress-app/releases/tag/tea-release.1.3.3)
+which now handles URLs with non-standard characters like colons
+* one additional change to the `tf` module to handle bucket versioning as required
+by the terraform aws version `>= 3.75.2`
 
 ## v15.0.3.1
 

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -1,5 +1,5 @@
 module "thin_egress_app" {
-  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.1.3.2.zip"
+  source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.1.3.3.zip"
 
   auth_base_url                      = var.urs_url
   bucket_map_file                    = local.bucket_map_key == null ? aws_s3_bucket_object.bucket_map_yaml.id : local.bucket_map_key

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -26,13 +26,17 @@ locals {
 
 resource "aws_s3_bucket" "backend-tf-state-bucket" {
   bucket = "${local.cumulus-prefix}-tf-state-${local.aws_account_id_last4}"
-  versioning {
-    enabled = true
-  }
   lifecycle {
     prevent_destroy = true
   }
   tags = local.default_tags
+}
+
+resource "aws_s3_bucket_versioning" "backend-tf-state-bucket-versioning" {
+  bucket = aws_s3_bucket.backend-tf-state-bucket.id
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_dynamodb_table" "backend-tf-locks-table" {


### PR DESCRIPTION
Had an issue where filenames with colons were not handled correctly.  Rohan upgraded TEA to include additional escaping of URL characters.  Resolved my issue.

I would like to create a new CIRRUS release with this change.