### PR TITLE
PR-4737 Undo bucket versioning config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v11.1.8.2
+
+* Undo changes to terraform bucket versioning config
+
 ## v11.1.8.1
 
 * Upgrade to [TEA Release 1.3.3](https://github.com/asfadmin/thin-egress-app/releases/tag/tea-release.1.3.3)

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -26,17 +26,13 @@ locals {
 
 resource "aws_s3_bucket" "backend-tf-state-bucket" {
   bucket = "${local.cumulus-prefix}-tf-state-${local.aws_account_id_last4}"
+  versioning {
+    enabled = true
+  }
   lifecycle {
     prevent_destroy = true
   }
   tags = local.default_tags
-}
-
-resource "aws_s3_bucket_versioning" "backend-tf-state-bucket-versioning" {
-  bucket = aws_s3_bucket.backend-tf-state-bucket.id
-  versioning_configuration {
-    status = "Enabled"
-  }
 }
 
 resource "aws_dynamodb_table" "backend-tf-locks-table" {


### PR DESCRIPTION
This was actually unrelated to the TEA upgrade even though it was included in the same commit.