### PR TITLE
Add metrics aws sns policy logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v15.0.3.3
+
+* Update outputs to match cumulus module
+* Add support for EMS Reporting SNS policy
+
 ## v15.0.3.2
 
 * Add 'lzards' support to cumulus module

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -6,17 +6,17 @@ output "workflow_config" {
 
 # ---------
 # Cumulus Tasks
-output "sf_sqs_report_task" {
-  value = module.cumulus.sf_sqs_report_task
-}
-output "fake_processing_task" {
-  value = module.cumulus.fake_processing_task
+output "add_missing_file_checksums_task" {
+  value = module.cumulus.add_missing_file_checksums_task
 }
 output "discover_granules_task" {
   value = module.cumulus.discover_granules_task
 }
 output "discover_pdrs_task" {
   value = module.cumulus.discover_pdrs_task
+}
+output "fake_processing_task" {
+  value = module.cumulus.fake_processing_task
 }
 output "files_to_granules_task" {
   value = module.cumulus.files_to_granules_task
@@ -27,6 +27,9 @@ output "hello_world_task" {
 output "hyrax_metadata_updates_task" {
   value = module.cumulus.hyrax_metadata_updates_task
 }
+output "lzards_backup_task" {
+  value = module.cumulus.lzards_backup_task
+}
 output "move_granules_task" {
   value = module.cumulus.move_granules_task
 }
@@ -36,21 +39,33 @@ output "parse_pdr_task" {
 output "pdr_status_check_task" {
   value = module.cumulus.pdr_status_check_task
 }
-output "post_to_cmr_task" {
-  value = module.cumulus.post_to_cmr_task
-}
+
 output "queue_granules_task" {
   value = module.cumulus.queue_granules_task
 }
 output "queue_pdrs_task" {
   value = module.cumulus.queue_pdrs_task
 }
+output "queue_workflow_task" {
+  value = module.cumulus.queue_workflow_task
+}
+output "sf_sqs_report_task" {
+  value = module.cumulus.sf_sqs_report_task
+}
 output "sync_granule_task" {
   value = module.cumulus.sync_granule_task
 }
-
+output "update_cmr_access_constraints_task" {
+  value = module.cumulus.update_cmr_access_constraints_task
+}
 output "update_granules_cmr_metadata_file_links_task" {
   value = module.cumulus.update_granules_cmr_metadata_file_links_task
+}
+output "post_to_cmr_task" {
+  value = module.cumulus.post_to_cmr_task
+}
+output "sqs2sfThrottle_lambda_function_arn" {
+  value = module.cumulus.sqs2sfThrottle_lambda_function_arn
 }
 
 # ---------
@@ -81,7 +96,13 @@ output "distribution_redirect_uri" {
 }
 
 # ---------
-# Workflow reporting SNS topics
+# Workflow reporting Queue and SNS topics
+output "stepfunction_event_reporter_queue_url" {
+  value = module.cumulus.stepfunction_event_reporter_queue_url
+}
+output "report_collections_sns_topic_arn" {
+  value = module.cumulus.report_collections_sns_topic_arn
+}
 output "report_executions_sns_topic_arn" {
   value = module.cumulus.report_executions_sns_topic_arn
 }

--- a/cumulus/policy.tf
+++ b/cumulus/policy.tf
@@ -1,9 +1,9 @@
 resource "aws_sns_topic_policy" "metrics_sns_policy" {
   for_each = var.metrics_es_aws_account_id != null ? {
-      "granules"    = module.cumulus.report_granules_sns_topic_arn
-      "executions"  = module.cumulus.report_executions_sns_topic_arn
-      "collections" = module.cumulus.report_collections_sns_topic_arn
-      "pdrs"        = module.cumulus.report_pdrs_sns_topic_arn
+    "granules"    = module.cumulus.report_granules_sns_topic_arn
+    "executions"  = module.cumulus.report_executions_sns_topic_arn
+    "collections" = module.cumulus.report_collections_sns_topic_arn
+    "pdrs"        = module.cumulus.report_pdrs_sns_topic_arn
   } : {}
   arn = each.value
 
@@ -12,18 +12,17 @@ resource "aws_sns_topic_policy" "metrics_sns_policy" {
 
 data "aws_iam_policy_document" "metrics_sns_topics_policy" {
   policy_id = "__default_policy_ID"
-  for_each =  var.metrics_es_aws_account_id != null ? {
-      "granules"    = module.cumulus.report_granules_sns_topic_arn
-      "executions"  = module.cumulus.report_executions_sns_topic_arn
-      "collections" = module.cumulus.report_collections_sns_topic_arn
-      "pdrs"        = module.cumulus.report_pdrs_sns_topic_arn
-    } : {}
+  for_each = var.metrics_es_aws_account_id != null ? {
+    "granules"    = module.cumulus.report_granules_sns_topic_arn
+    "executions"  = module.cumulus.report_executions_sns_topic_arn
+    "collections" = module.cumulus.report_collections_sns_topic_arn
+    "pdrs"        = module.cumulus.report_pdrs_sns_topic_arn
+  } : {}
 
   statement {
     actions = [
       "SNS:Subscribe",
     ]
-
 
     effect = "Allow"
 

--- a/cumulus/policy.tf
+++ b/cumulus/policy.tf
@@ -1,0 +1,41 @@
+resource "aws_sns_topic_policy" "metrics_sns_policy" {
+  for_each = var.metrics_es_aws_account_id != null ? {
+      "granules"    = module.cumulus.report_granules_sns_topic_arn
+      "executions"  = module.cumulus.report_executions_sns_topic_arn
+      "collections" = module.cumulus.report_collections_sns_topic_arn
+      "pdrs"        = module.cumulus.report_pdrs_sns_topic_arn
+  } : {}
+  arn = each.value
+
+  policy = data.aws_iam_policy_document.metrics_sns_topics_policy[each.key].json
+}
+
+data "aws_iam_policy_document" "metrics_sns_topics_policy" {
+  policy_id = "__default_policy_ID"
+  for_each =  var.metrics_es_aws_account_id != null ? {
+      "granules"    = module.cumulus.report_granules_sns_topic_arn
+      "executions"  = module.cumulus.report_executions_sns_topic_arn
+      "collections" = module.cumulus.report_collections_sns_topic_arn
+      "pdrs"        = module.cumulus.report_pdrs_sns_topic_arn
+    } : {}
+
+  statement {
+    actions = [
+      "SNS:Subscribe",
+    ]
+
+
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = [var.metrics_es_aws_account_id]
+    }
+
+    resources = [
+      each.value,
+    ]
+
+    sid = "__default_statement_ID"
+  }
+}

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -64,8 +64,8 @@ variable "lzards_provider" {
 
 variable "lzards_api" {
   description = "LZARDS backup API endpoint"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "lzards_s3_link_timeout" {
@@ -388,8 +388,8 @@ variable "thottled_queue_execution_limit" {
 
 variable "lambda_memory_sizes" {
   description = "Memory sizes for lambda functions"
-  type = map(string)
-  default = {}
+  type        = map(string)
+  default     = {}
 }
 
 variable "lambda_timeouts" {
@@ -411,8 +411,8 @@ variable "cloudwatch_log_retention_periods" {
 }
 
 variable "default_log_retention_days" {
-  type = number
-  default = 30
+  type        = number
+  default     = 30
   description = "Optional default value that user chooses for their log retention periods"
 }
 

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -254,6 +254,11 @@ variable "metrics_es_username" {
   default = null
 }
 
+variable "metrics_es_aws_account_id" {
+  type    = string
+  default = null
+}
+
 variable "api_users" {
   type    = list(string)
   default = []


### PR DESCRIPTION
This adds some missing outputs that are exposed by the cumulus module. I was attempting to add the policy generation for the metrics team to have SNS subscribe permissions. This change is optional to other DAACs but the cumulus resources that are created for reporting do not have the ability by default to be subscribed to by the metrics AWS accounts. 

Some information can be found here https://wiki.earthdata.nasa.gov/display/METS/2.+(Tenant)+Shipping+Logs+To+Cloud+Metrics'+AWS+Account

The outputs I decided to refresh since I was in the account. I got the current list from here https://github.com/nasa/cumulus/blob/v15.0.3/tf-modules/cumulus/outputs.tf

- [x] Added change log entry
- [x] Tested

This creates the ability for DAACs to add maturity specific accounts to the policy via the `metrics_es_aws_account_id` variable. 