### PR TITLE
fix: remove trailing / from urs_url

### DIFF
--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -267,7 +267,7 @@ variable "api_users" {
 variable "urs_url" {
   description = "The URL of the Earthdata login (URS) site"
   type        = string
-  default     = "https://uat.urs.earthdata.nasa.gov/"
+  default     = "https://uat.urs.earthdata.nasa.gov"
 }
 
 variable "deploy_distribution_s3_credentials_endpoint" {


### PR DESCRIPTION
The trailing `/` in `https://uat.urs.earthdata.nasa.gov/ ` causes the error below. This PR removes it. 

Fix error `ValidationError: Parameter 'AuthBaseUrl' must be one of AllowedValues`
