### PR TITLE
upgrade Cumulus to v16.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 ## v16.0.0.0
 
 * Upgrade to [Cumulus v16.0.0](https://github.com/nasa/Cumulus/releases/tag/v16.0.0)
-* **Note**: When upgrading to cumulus 16.0.0 `make cumulus` tries to delete 3 lambda
-functions and their associated cloudwatch log groups.  It gets stuck in a cycle.
-The `scripts/cumulus-v16.0.0/delete_log_groups.sh` script deletes the log groups
-which then allows `make cumulus` to complete
+* ***BUG***:  This version of Cumulus has a bug for async operations.  Issue
+[CUMULUS-3382](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3382) has been opened
+to track this issue and it should be resolved in a future version of Cumulus.
 
+* **Note**: When upgrading to cumulus 16.0.0 `make cumulus` tries to delete 3 lambda
+functions and their associated cloudwatch log groups.  For some deployments it gets
+stuck in a cycle.  The `scripts/cumulus-v16.0.0/delete_log_groups.sh` script
+deletes the log groups which then allows `make cumulus` to complete
 
 ```
 Error: Cycle: module.cumulus.module.archive.aws_lambda_function.granule_files_cache_updater (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.granule_files_cache_updater_logs (destroy)
@@ -16,7 +19,6 @@ Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_pdrs (de
 
 Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_granules (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.publish_granules_logs (destroy)
 ```
-
 
 
 ## v15.0.3.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 ## v16.0.0.0
 
 * Upgrade to [Cumulus v16.0.0](https://github.com/nasa/Cumulus/releases/tag/v16.0.0)
+* **Note**: When upgrading to cumulus 16.0.0 `make cumulus` tries to delete 3 lambda
+functions and their associated cloudwatch log groups.  It gets stuck in a cycle.
+The `scripts/cumulus-v16.0.0/delete_log_groups.sh` script deletes the log groups
+which then allows `make cumulus` to complete
+
+
+```
+Error: Cycle: module.cumulus.module.archive.aws_lambda_function.granule_files_cache_updater (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.granule_files_cache_updater_logs (destroy)
+
+Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_pdrs (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.publish_pdrs_logs (destroy)
+
+Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_granules (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.publish_granules_logs (destroy)
+```
+
+
 
 ## v15.0.3.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v16.0.0.0
+
+* Upgrade to [Cumulus v16.0.0](https://github.com/nasa/Cumulus/releases/tag/v16.0.0)
+
 ## v15.0.3.3
 
 * Update outputs to match cumulus module

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #  PYTHON_VER: 			  python3 or python38 which sets the build target in make file
 
 # ---------------------------
-DOCKER_TAG := v15.0.3.0
+DOCKER_TAG := v16.0.0.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v16.0.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 

--- a/data-migration1/main.tf
+++ b/data-migration1/main.tf
@@ -57,7 +57,7 @@ data "terraform_remote_state" "rds" {
 }
 
 module "data_migration1" {
-  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus-data-migrations1.zip"
+  source = "https://github.com/nasa/cumulus/releases/download/v16.0.0/terraform-aws-cumulus-data-migrations1.zip"
 
   prefix = local.prefix
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -20,7 +20,7 @@ provider "aws" {
 }
 
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v15.0.3/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v16.0.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnet_ids.subnet_ids.ids

--- a/scripts/cumulus-v16.0.0/delete_log_groups.sh
+++ b/scripts/cumulus-v16.0.0/delete_log_groups.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# when upgrading to cumulus 16.0.0 the "make cumulus" tries to delete 3 lambda
+# functions and their associated log groups.  It gets stuck in a cycle
+#
+#  Error: Cycle: module.cumulus.module.archive.aws_lambda_function.granule_files_cache_updater (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.granule_files_cache_updater_logs (destroy)
+#
+#  Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_pdrs (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.publish_pdrs_logs (destroy)
+#
+#  Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_granules (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.publish_granules_logs (destroy)
+#
+# this script deletes the log groups.  After they are deleted "make cumulus"
+# runs successfully
+
+aws logs delete-log-group --log-group-name "/aws/lambda/${DEPLOY_NAME}-cumulus-${MATURITY}-granuleFilesCacheUpdater"
+aws logs delete-log-group --log-group-name "/aws/lambda/${DEPLOY_NAME}-cumulus-${MATURITY}-publishPdrs"
+aws logs delete-log-group --log-group-name "/aws/lambda/${DEPLOY_NAME}-cumulus-${MATURITY}-publishGranules"


### PR DESCRIPTION
I wanted to get this out, but when I tried `make cumulus` I got these errors:

```
Error: Cycle: module.cumulus.module.archive.aws_lambda_function.granule_files_cache_updater (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.granule_files_cache_updater_logs (destroy)

Error: Cycle: module.cumulus.module.archive.aws_lambda_function.publish_granules (destroy), module.cumulus.module.archive.aws_cloudwatch_log_group.publish_granules_logs (destroy)

Error: Cycle: module.cumulus.module.archive.aws_cloudwatch_log_group.publish_pdrs_logs (destroy), module.cumulus.module.archive.aws_lambda_function.publish_pdrs (destroy)
```

I anticipate more changes before merging.
