### PR TITLE
Update Dockerfile to address ssh-keygen errors on current image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## Unreleased
+
+* Update build Dockerfile to assign a username to UID 502 in the AWS Linux 2 image to
+  mitigate ssh-keygen errors when not assigned
+
 ## v16.0.0.0
 
 * Upgrade to [Cumulus v16.0.0](https://github.com/nasa/Cumulus/releases/tag/v16.0.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,10 @@ RUN \
         curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm" &&\
         yum install -y session-manager-plugin.rpm
 
+# Add user to /etc/passwd for keygen in Makefile 
+RUN \
+        echo "user:x:502:0:root:/:/bin/bash" >> /etc/passwd
+
 WORKDIR /CIRRUS-core
 
 # Python38 target


### PR DESCRIPTION
This is a fix for the issue reported in https://github.com/asfadmin/CIRRUS-core/issues/162