### PR TITLE
Update Dockerfile to address ssh-keygen errors on current image v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+
+* Update build Dockerfile to create an entry in /etc/passwd for the user building
+  the image.  It allows the `setup_jwt_cookie.sh` script to be run inside the
+  container.
+
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)
 * Upgrade terraform modules to use AWS provider version 5.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ RUN \
 # Add user for keygen in Makefile
 ARG USER
 RUN \
-        useradd -u ${USER} user
+        echo "user:x:${USER}:0:root:/:/bin/bash" >> /etc/passwd
 
 WORKDIR /CIRRUS-core
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,6 +41,11 @@ RUN \
         curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm" &&\
         yum install -y session-manager-plugin.rpm
 
+# Add user to /etc/passwd for keygen in Makefile
+ARG USER
+RUN \
+        echo "user:x:${USER}:0:root:/:/bin/bash" >> /etc/passwd
+
 WORKDIR /CIRRUS-core
 
 # Python38 target

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,10 @@ RUN \
         curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm" &&\
         yum install -y session-manager-plugin.rpm
 
-# Add user to /etc/passwd for keygen in Makefile
+# Add user for keygen in Makefile
 ARG USER
 RUN \
-        echo "user:x:${USER}:0:root:/:/bin/bash" >> /etc/passwd
+        useradd -u ${USER} user
 
 WORKDIR /CIRRUS-core
 

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ endef
 # ---------------------------
 .PHONY: image
 image: Dockerfile
-	docker build -f Dockerfile --no-cache -t cirrus-core:$(DOCKER_TAG) --target $(PYTHON_VER) .
+	docker build -f Dockerfile --no-cache -t cirrus-core:$(DOCKER_TAG) --target $(PYTHON_VER) --build-arg USER=`id -u` .
 
 .PHONY: container-shell
 container-shell:


### PR DESCRIPTION
I took it as a challenge to come up with a generic way to implement the changes needed to resolve issue #162 and proposed in PR #163 