### PR TITLE
Add `deploy_cumulus_distribution` variable to cumulus module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v15.0.3.4
+
+* Add `deploy_cumulus_distribution` variable to cumulus module
+
 ## v15.0.3.3
 
 * Update outputs to match cumulus module

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -98,6 +98,7 @@ module "cumulus" {
   api_gateway_stage           = var.MATURITY
   log_destination_arn         = var.log_destination_arn
 
+  deploy_cumulus_distribution                 = var.deploy_cumulus_distribution
   deploy_distribution_s3_credentials_endpoint = var.deploy_distribution_s3_credentials_endpoint
 
   additional_log_groups_to_elk = var.additional_log_groups_to_elk

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -270,6 +270,12 @@ variable "urs_url" {
   default     = "https://uat.urs.earthdata.nasa.gov/"
 }
 
+variable "deploy_cumulus_distribution" {
+  description = "If true, does not deploy the TEA distribution API"
+  type        = bool
+  default     = true
+}
+
 variable "deploy_distribution_s3_credentials_endpoint" {
   description = "Whether or not to include the S3 credentials endpoint in the Thin Egress App"
   type        = bool


### PR DESCRIPTION
Need access to this variable so we can disable the `TeaCache` lambda.