### PR TITLE
Add orca DAAC module configuration hooks into CIRRUS-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## v17.0.1.0
+* Add orca_recovery_adapter_task cumulus core module output added in cumulus v17
+
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)
 * Upgrade terraform modules to use AWS provider version 5.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ variable "use_orca" {
 }
 ```
 
-* Updates `cumulus` module behavior such that when `use orca` is set to true, the module reads a cirrus-daac module `orca`'s remote state via convention and uses the following remote state values to to pass configuration values to the `cumulus` module:
+* Updates `cumulus` module behavior such that when `use_orca` is set to true, the module reads a cirrus-daac module `orca`'s remote state via convention and uses the following remote state values to to pass configuration values to the `cumulus` module:
   * outputs.orca.orca_lambda_copy_to_archive_arn
   * outputs.orca.orca_sfn_recovery_workflow_arn
   * outputs.orca.orca_api_uri

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@
 * Update core `cumulus` module to allow for an Orca module that provides configuration values via remote state for the following Cumulus module variables:
   * orca_lambda_copy_to_archive_arn
   * orca_sfn_recovery_workflow_arn
+  * orca_api_uri
 
 * Adds the following configuration variable:
 
 ```tf
 variable "use_orca" {
-  description = "Use orca - rely on remote state convention to bring in ORCA lambdas" 
+  description = "If set to true, pull in remote state values from 'orca' module to configure cumulus core module for ORCA" 
   type = bool
   default = false
 }
@@ -23,6 +24,7 @@ variable "use_orca" {
 * Updates `cumulus` module behavior such that when `use orca` is set to true, the module reads a cirrus-daac module `orca`'s remote state via convention and uses the following remote state values to to pass configuration values to the `cumulus` module:
   * outputs.orca.orca_lambda_copy_to_archive_arn
   * outputs.orca.orca_sfn_recovery_workflow_arn
+  * outputs.orca.orca_api_uri
 
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,28 @@
 # CHANGELOG
 
 ## v17.0.1.0
-* Add orca_recovery_adapter_task cumulus core module output added in cumulus v17
+
+* Adds the following outputs to the `cumulus` cirrus module that were added to the cumulus core module output added in cumulus v17:
+  * "orca_recovery_adapter_task"
+  * "orca_copy_to_archive_adapter_task"
+
+* Update core `cumulus` module to allow for an Orca module that provides configuration values via remote state for the following Cumulus module variables:
+  * orca_lambda_copy_to_archive_arn
+  * orca_sfn_recovery_workflow_arn
+
+* Adds the following configuration variable:
+
+```tf
+variable "use_orca" {
+  description = "Use orca - rely on remote state convention to bring in ORCA lambdas" 
+  type = bool
+  default = false
+}
+```
+
+* Updates `cumulus` module behavior such that when `use orca` is set to true, the module reads a cirrus-daac module `orca`'s remote state via convention and uses the following remote state values to to pass configuration values to the `cumulus` module:
+  * outputs.orca.orca_lambda_copy_to_archive_arn
+  * outputs.orca.orca_sfn_recovery_workflow_arn
 
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,6 @@
 
 ## v17.0.0.2
 
-* Add `deploy_cumulus_distribution` variable to cumulus module
-* Update build Dockerfile to create an entry in /etc/passwd for the user building
-  the image.  It allows the `setup_jwt_cookie.sh` script to be run inside the
-  container.
-* update Node version to 16.x in Docker file to support v12.0.1 of the
-[Cumulus Dashboard](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.1)
-
-## v17.0.0.1
-
 * Adds the following outputs to the `cumulus` cirrus module that were added to the cumulus core module output added in cumulus v17:
   * "orca_recovery_adapter_task"
   * "orca_copy_to_archive_adapter_task"
@@ -34,6 +25,15 @@ variable "use_orca" {
   * outputs.orca.orca_lambda_copy_to_archive_arn
   * outputs.orca.orca_sfn_recovery_workflow_arn
   * outputs.orca.orca_api_uri
+
+## v17.0.0.1
+
+* Add `deploy_cumulus_distribution` variable to cumulus module
+* Update build Dockerfile to create an entry in /etc/passwd for the user building
+  the image.  It allows the `setup_jwt_cookie.sh` script to be run inside the
+  container.
+* update Node version to 16.x in Docker file to support v12.0.1 of the
+[Cumulus Dashboard](https://github.com/nasa/cumulus-dashboard/releases/tag/v12.0.1)
 
 ## v17.0.0.0
 * Upgrade to [Cumulus v17.0.0](https://github.com/nasa/cumulus/releases/tag/v17.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # CHANGELOG
 
-## v17.0.1.0
+## v17.0.0.1
 
 * Adds the following outputs to the `cumulus` cirrus module that were added to the cumulus core module output added in cumulus v17:
   * "orca_recovery_adapter_task"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #  PYTHON_VER: 			  python3 or python38 which sets the build target in make file
 
 # ---------------------------
-DOCKER_TAG := v17.0.1.0
+DOCKER_TAG := v17.0.0.1
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}
@@ -192,7 +192,6 @@ cumulus: cumulus-init
 	fi
 	export TF_CMD="terraform apply \
 				-var-file=${DAAC_DIR}/$@/terraform.tfvars \
-				$$VARIABLES_OPT \
 				$$SECRETS_OPT \
 				-input=false \
 				-no-color \

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@
 #  PYTHON_VER: 			  python3 or python38 which sets the build target in make file
 
 # ---------------------------
-DOCKER_TAG := v17.0.0.0
+DOCKER_TAG := v17.0.1.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ cumulus: cumulus-init
 	fi
 	export TF_CMD="terraform apply \
 				-var-file=${DAAC_DIR}/$@/terraform.tfvars \
+				$$VARIABLES_OPT \
 				$$SECRETS_OPT \
 				-input=false \
 				-no-color \

--- a/cumulus/common.tf
+++ b/cumulus/common.tf
@@ -65,6 +65,7 @@ locals {
   }
   orca_lambda_copy_to_archive_arn = var.use_orca == true ? data.terraform_remote_state.orca[0].outputs.orca_module.orca_lambda_copy_to_archive_arn : ""
   orca_sfn_recovery_workflow_arn = var.use_orca == true ? data.terraform_remote_state.orca[0].outputs.orca_module.orca_sfn_recovery_workflow_arn : ""
+  orca_api_uri = var.use_orca == true ? data.terraform_remote_state.orca[0].outputs.orca_module.orca_api_deployment_invoke_url : ""
 }
 
 data "aws_caller_identity" "current" {}

--- a/cumulus/common.tf
+++ b/cumulus/common.tf
@@ -58,6 +58,13 @@ locals {
   default_tags = {
     Deployment = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}"
   }
+  orca_remote_state_config = {
+    bucket = "${var.DEPLOY_NAME}-cumulus-${var.MATURITY}-tf-state-${substr(data.aws_caller_identity.current.account_id, -4, 4)}"
+    key    = "orca/terraform.tfstate"
+    region = data.aws_region.current.name
+  }
+  orca_lambda_copy_to_archive_arn = var.use_orca == true ? data.terraform_remote_state.orca[0].outputs.orca_module.orca_lambda_copy_to_archive_arn : ""
+  orca_sfn_recovery_workflow_arn = var.use_orca == true ? data.terraform_remote_state.orca[0].outputs.orca_module.orca_sfn_recovery_workflow_arn : ""
 }
 
 data "aws_caller_identity" "current" {}

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -83,6 +83,7 @@ module "cumulus" {
 
   orca_lambda_copy_to_archive_arn = local.orca_lambda_copy_to_archive_arn
   orca_sfn_recovery_workflow_arn  = local.orca_sfn_recovery_workflow_arn
+  orca_api_uri = local.orca_api_uri
 
   # must match stage_name variable for thin-egress-app module
   tea_api_gateway_stage = local.tea_stage_name

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -81,6 +81,9 @@ module "cumulus" {
   archive_api_users = var.api_users
   archive_api_url   = var.archive_api_url
 
+  orca_lambda_copy_to_archive_arn = local.orca_lambda_copy_to_archive_arn
+  orca_sfn_recovery_workflow_arn  = local.orca_sfn_recovery_workflow_arn
+
   # must match stage_name variable for thin-egress-app module
   tea_api_gateway_stage = local.tea_stage_name
 

--- a/cumulus/orca.tf
+++ b/cumulus/orca.tf
@@ -1,7 +1,0 @@
-
-data "terraform_remote_state" "orca" {
-  count = var.use_orca == true ? 1 : 0
-  backend   = "s3"
-  workspace = var.DEPLOY_NAME
-  config    = local.orca_remote_state_config
-}

--- a/cumulus/orca.tf
+++ b/cumulus/orca.tf
@@ -1,0 +1,7 @@
+
+data "terraform_remote_state" "orca" {
+  count = var.use_orca == true ? 1 : 0
+  backend   = "s3"
+  workspace = var.DEPLOY_NAME
+  config    = local.orca_remote_state_config
+}

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -37,6 +37,11 @@ output "move_granules_task" {
 output "orca_recovery_adapter_task" {
   value = module.cumulus.orca_recovery_adapter_task
 }
+
+output "orca_copy_to_archive_adapter_task" {
+  value = module.cumulus.orca_copy_to_archive_adapter_task
+}
+
 output "parse_pdr_task" {
   value = module.cumulus.parse_pdr_task
 }

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -33,6 +33,10 @@ output "lzards_backup_task" {
 output "move_granules_task" {
   value = module.cumulus.move_granules_task
 }
+
+output "orca_recovery_adapter_task" {
+  value = module.cumulus.orca_recovery_adapter_task
+}
 output "parse_pdr_task" {
   value = module.cumulus.parse_pdr_task
 }

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -29,6 +29,8 @@ variable "cmr_oauth_provider" {
   default = "earthdata"
 }
 
+
+
 variable "launchpad_api" {
   type    = string
   default = "launchpadApi"
@@ -82,6 +84,24 @@ variable "oauth_provider" {
 variable "oauth_user_group" {
   type    = string
   default = "N/A"
+}
+
+variable "orca_lambda_copy_to_archive_arn" {
+  description = "AWS ARN of the ORCA copy_to_archive lambda."
+  type        = string
+  default     = ""
+}
+
+variable "orca_sfn_recovery_workflow_arn" {
+  description = "The ARN of the recovery step function."
+  type        = string
+  default     = ""
+}
+
+variable "use_orca" {
+  description = "Use orca - rely on remote state convention to bring in ORCA lambdas"
+  type = bool
+  default = false
 }
 
 variable "s3_replicator_config" {

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -99,7 +99,7 @@ variable "orca_sfn_recovery_workflow_arn" {
 }
 
 variable "use_orca" {
-  description = "If set to true, pull in remote state values to configure cumulus core module for ORCA"
+  description = "If set to true, pull in remote state values from 'orca' module to configure cumulus core module for ORCA"
   type = bool
   default = false
 }

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -93,13 +93,13 @@ variable "orca_lambda_copy_to_archive_arn" {
 }
 
 variable "orca_sfn_recovery_workflow_arn" {
-  description = "The ARN of the recovery step function."
+  description = "The ARN of the ORCA sfn_recovery_workflow"
   type        = string
   default     = ""
 }
 
 variable "use_orca" {
-  description = "Use orca - rely on remote state convention to bring in ORCA lambdas"
+  description = "If set to true, pull in remote state values to configure cumulus core module for ORCA"
   type = bool
   default = false
 }


### PR DESCRIPTION
This PR adds a new Core output from v17 that's needed to integrate Orca with CIRRUS. 