### PR TITLE
Pass tags parameter to TEA module

### DIFF
--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -21,6 +21,7 @@ module "thin_egress_app" {
   urs_auth_creds_secret_name         = aws_secretsmanager_secret.thin_egress_urs_creds.name
   use_cors                           = var.use_cors
   vpc_subnet_ids                     = data.aws_subnets.subnet_ids.ids
+  tags                               = local.default_tags
 }
 
 resource "aws_secretsmanager_secret" "thin_egress_urs_creds" {


### PR DESCRIPTION
The tags are applied to the cloudformation stack and a security group. The security group also happens to be unnamed which makes it very hard to track down for cleanup in dev accounts.