### PR TITLE
pin to 5.22 or less

### DIFF
--- a/cumulus/provider.tf
+++ b/cumulus/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "<= 5.22.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/data-persistence/provider.tf
+++ b/data-persistence/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "<= 5.22.0"
     }
     null = {
       source  = "hashicorp/null"

--- a/tf/provider.tf
+++ b/tf/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "<= 5.22.0"
     }
   }
 }


### PR DESCRIPTION
this is to temporarily pin to 5.22 aws provider while we wait for a release from tf