### PR TITLE
update Makefile docker commands to support Apple Silicon machines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # CHANGELOG
+
+## Unreleased
+
+* add `--platform linux/amd64` to all Docker commands in `Makefile` so `make image` and
+`make container-shell` work on Apple Silicon machines
+
 ## v18.0.0.1
 
 * Remove terraform lockfiles to ensure easy upgrade to v18 and ratchet provider versions

--- a/Makefile
+++ b/Makefile
@@ -52,11 +52,17 @@ endef
 # ---------------------------
 .PHONY: image
 image: Dockerfile
-	docker build -f Dockerfile --no-cache -t cirrus-core:$(DOCKER_TAG) --target $(PYTHON_VER) --build-arg USER=`id -u` .
+	docker build -f Dockerfile \
+		--platform linux/amd64 \
+		--no-cache \
+		-t cirrus-core:$(DOCKER_TAG) \
+		--target $(PYTHON_VER) \
+		--build-arg USER=`id -u` .
 
 .PHONY: container-shell
 container-shell:
 	docker run -it --rm \
+		--platform linux/amd64 \
 		--user `id -u` \
 		--env DAAC_DIR="/CIRRUS-DAAC" \
 		--env AWS_CONFIG_DIR="/" \


### PR DESCRIPTION
I recently started using an Apple Silicon machine and found I had to add the specific platform to the docker commands to make them work.