### PR TITLE
Allow importing of egress_lambda_log_group if getting an "already exists" error

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,3 @@
+[safe]
+	directory = /CIRRUS-core
+	directory = /CIRRUS-DAAC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## unreleased
+* add a Makefile target to import tea lambda cloudwatch group if getting an "The
+specified log group already exists" error: `make import-thin-egress-log`
+* add .gitconfig file to Docker image to mark /CIRRUS-core and /CIRRUS-DAAC as safe
+
 ## v18.2.0.0
 
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,8 @@ ARG USER
 RUN \
         echo "user:x:${USER}:0:root:/:/bin/bash" >> /etc/passwd
 
+COPY .gitconfig /.gitconfig
+
 WORKDIR /CIRRUS-core
 
 # Python38 target

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ import-thin-egress-log: cumulus-init
 				-input=false \
 				-no-color \
 				aws_cloudwatch_log_group.egress_lambda_log_group[0] \
-				${DEPLOY_NAME}-cumulus-${MATURITY}-thin-egress-app-EgressLambda"
+				/aws/lambda/${DEPLOY_NAME}-cumulus-${MATURITY}-thin-egress-app-EgressLambda"
 	eval $$TF_CMD
 
 # ---------------------------

--- a/cumulus/tea-cloudwatch.tf.example
+++ b/cumulus/tea-cloudwatch.tf.example
@@ -1,5 +1,3 @@
-
-
 # If you run into this issue when deploying Cumulus
 #
 # Error: creating CloudWatch Logs Log Group

--- a/cumulus/tea-cloudwatch.tf.example
+++ b/cumulus/tea-cloudwatch.tf.example
@@ -1,0 +1,39 @@
+
+
+# If you run into this issue when deploying Cumulus
+#
+# Error: creating CloudWatch Logs Log Group
+# (/aws/lambda/DEPLOY_NAME-cumulus-MATURITY-thin-egress-app-EgressLambda): operation
+# error CloudWatch Logs: CreateLogGroup, https response error StatusCode: 400,
+# RequestID: XXXX, ResourceAlreadyExistsException: The specified log group already
+# exists
+#
+#  with aws_cloudwatch_log_group.egress_lambda_log_group[0],
+#  on thin-egress.tf line 67, in resource "aws_cloudwatch_log_group" "egress_lambda_log_group":
+#  67: resource "aws_cloudwatch_log_group" "egress_lambda_log_group" {
+#
+# You can rename this file from tea-cloudwatch.tf.example to tea-cloudwatch.tf and then
+# fill in the 'id' for your cloudwatch group.
+#
+# Terraform 1.5.x requires the 'id' of the import statement to be a string, it can't
+# even be a variable that is a string.
+#
+# https://developer.hashicorp.com/terraform/language/v1.5.x/import
+#
+# Later versions of Terraform do allow a variable, but it can't a calculated value
+#
+# https://developer.hashicorp.com/terraform/language/v1.6.x/import
+#
+# The thin egress cloudwatch group follows this pattern and should have been reported
+# in the error message
+#
+#  /aws/lambda/DEPLOY_NAME-cumulus-MATURITY-thin-egress-app-EgressLambda
+
+import {
+  to = aws_cloudwatch_log_group.egress_lambda_log_group[0]
+  id = ""
+}
+
+output "imported_tea_log_group" {
+  value = aws_cloudwatch_log_group.egress_lambda_log_group
+}

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -64,38 +64,20 @@ resource "aws_cloudwatch_log_subscription_filter" "egress_api_gateway_log_subscr
 }
 
 # Egress Lambda Log Group
-# does it already exist
-data "aws_cloudwatch_log_group" "egress_lambda_log_group" {
-  name = "/aws/lambda/${module.thin_egress_app.egress_lambda_name}"
-}
-
 resource "aws_cloudwatch_log_group" "egress_lambda_log_group" {
-  count             = (var.log_destination_arn != null && data.aws_cloudwatch_log_group.egress_lambda_log_group == null) ? 1 : 0
+  count             = (var.log_destination_arn != null) ? 1 : 0
   name              = "/aws/lambda/${module.thin_egress_app.egress_lambda_name}"
   retention_in_days = var.egress_lambda_log_retention_days
   tags              = local.default_tags
 }
 
 # Egress Lambda Log Group Filter
-# if log group just created
-resource "aws_cloudwatch_log_subscription_filter" "egress_lambda_log_subscription_filter_new" {
-  count           = (var.log_destination_arn != null && data.aws_cloudwatch_log_group.egress_lambda_log_group == null) ? 1 : 0
+resource "aws_cloudwatch_log_subscription_filter" "egress_lambda_log_subscription_filter" {
+  count           = (var.log_destination_arn != null) ? 1 : 0
   depends_on      = [aws_cloudwatch_log_group.egress_lambda_log_group]
   name            = "${local.prefix}-EgressLambdaLogSubscriptionToSharedDestination"
   destination_arn = var.log_destination_arn
   distribution    = "ByLogStream"
   filter_pattern  = ""
   log_group_name  = aws_cloudwatch_log_group.egress_lambda_log_group[0].name
-}
-
-# Egress Lambda Log Group Filter
-# if log group already exists
-resource "aws_cloudwatch_log_subscription_filter" "egress_lambda_log_subscription_filter_update" {
-  count           = (var.log_destination_arn != null && data.aws_cloudwatch_log_group.egress_lambda_log_group != null) ? 1 : 0
-  depends_on      = [data.aws_cloudwatch_log_group.egress_lambda_log_group]
-  name            = "${local.prefix}-EgressLambdaLogSubscriptionToSharedDestination"
-  destination_arn = var.log_destination_arn
-  distribution    = "ByLogStream"
-  filter_pattern  = ""
-  log_group_name  = data.aws_cloudwatch_log_group.egress_lambda_log_group.name
 }


### PR DESCRIPTION
When I run `make cumulus` for an environment that sends logs to Cloud Metrics, UAT and Prod for me, I often get this error:

```
Error: creating CloudWatch Logs Log Group (/aws/lambda/my-environment-thin-egress-app-EgressLambda): 
operation error CloudWatch Logs: CreateLogGroup, https response error StatusCode: 400, 
RequestID: dbde8490-6ccb-495f-98c8-5bcdcbb6b2f7, ResourceAlreadyExistsException: The specified log 
group already exists
```

These lines:

https://github.com/asfadmin/CIRRUS-core/blob/master/cumulus/thin-egress.tf#L67-L72

This PR attempts to only create the log group if it doesn't already exist.  It also creates the Cloud Metrics subscription based on the whether the log watch group was just created or already exists.