### PR TITLE
Updates made on NSIDC Fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## Unreleased
+* Added separate urs_tea_client_id and urs_tea_client_password that can be specified if these are different from the non-tea versions of the variables.
+* Added optional ecs_include_docker_cleanup_cronjob variable, defaulting to False.
+* Fixed the value of the output report_granules_sns_topic_arn to point to module.cumulus.report_granules_sns_topic_arn instead of report_executions_sns_topic_arn.
+* Updated aws_s3_object.bucket_map_yaml so we only deploy this TEA bucket map when we don't provide a bucket_map_key from the daac module.
+
 ## v18.2.0.0
 
 * Upgrade to [Cumulus v18.2.0](https://github.com/nasa/cumulus/releases/tag/v18.2.0)

--- a/cumulus/locals.tf
+++ b/cumulus/locals.tf
@@ -42,4 +42,7 @@ locals {
   default_tags = {
     Deployment = local.prefix
   }
+
+  urs_tea_client_id = var.urs_tea_client_id != null ? var.urs_tea_client_id : var.urs_client_id
+  urs_tea_client_password = var.urs_tea_client_password != null ? var.urs_tea_client_id : var.urs_client_password
 }

--- a/cumulus/locals.tf
+++ b/cumulus/locals.tf
@@ -44,5 +44,5 @@ locals {
   }
 
   urs_tea_client_id = var.urs_tea_client_id != null ? var.urs_tea_client_id : var.urs_client_id
-  urs_tea_client_password = var.urs_tea_client_password != null ? var.urs_tea_client_id : var.urs_client_password
+  urs_tea_client_password = var.urs_tea_client_password != null ? var.urs_tea_client_password : var.urs_client_password
 }

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -115,6 +115,8 @@ module "cumulus" {
     execution_limit = var.thottled_queue_execution_limit
   }]
 
+  ecs_include_docker_cleanup_cronjob = var.ecs_include_docker_cleanup_cronjob
+
   tags = local.default_tags
 }
 

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -116,7 +116,7 @@ output "report_executions_sns_topic_arn" {
   value = module.cumulus.report_executions_sns_topic_arn
 }
 output "report_granules_sns_topic_arn" {
-  value = module.cumulus.report_executions_sns_topic_arn
+  value = module.cumulus.report_granules_sns_topic_arn
 }
 output "report_pdrs_sns_topic_arn" {
   value = module.cumulus.report_pdrs_sns_topic_arn

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -2,7 +2,7 @@ module "thin_egress_app" {
   source = "s3::https://s3.amazonaws.com/asf.public.code/thin-egress-app/tea-terraform-build.1.3.5.zip"
 
   auth_base_url                      = var.urs_url
-  bucket_map_file                    = local.bucket_map_key == null ? aws_s3_object.bucket_map_yaml.id : local.bucket_map_key
+  bucket_map_file                    = local.bucket_map_key == null ? aws_s3_object.bucket_map_yaml[0].id : local.bucket_map_key
   bucketname_prefix                  = ""
   config_bucket                      = local.system_bucket
   cookie_domain                      = var.thin_egress_cookie_domain
@@ -41,6 +41,8 @@ resource "aws_secretsmanager_secret_version" "thin_egress_urs_creds" {
 }
 
 resource "aws_s3_object" "bucket_map_yaml" {
+  # If bucket_map_key is set, we already have a bucket map on S3 and don't need to create one
+  count = local.bucket_map_key == null ? 1 : 0
   bucket = local.system_bucket
   key    = "${local.prefix}/thin-egress-app/${local.prefix}-bucket_map.yaml"
   content = templatefile("./thin-egress-app/bucket_map.yaml.tmpl", {

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -35,8 +35,8 @@ resource "aws_secretsmanager_secret" "thin_egress_urs_creds" {
 resource "aws_secretsmanager_secret_version" "thin_egress_urs_creds" {
   secret_id = aws_secretsmanager_secret.thin_egress_urs_creds.id
   secret_string = jsonencode({
-    UrsId   = var.urs_client_id
-    UrsAuth = base64encode("${var.urs_client_id}:${var.urs_client_password}")
+    UrsId   = local.urs_tea_client_id
+    UrsAuth = base64encode("${local.urs_tea_client_id}:${local.urs_tea_client_password}")
   })
 }
 

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -41,7 +41,7 @@ resource "aws_secretsmanager_secret_version" "thin_egress_urs_creds" {
 }
 
 resource "aws_s3_object" "bucket_map_yaml" {
-  # If bucket_map_key is set, we already have a bucket map on S3 and don't need to create one
+  # If bucket_map_key is set, the daac module already created one and we can skip creation here
   count = local.bucket_map_key == null ? 1 : 0
   bucket = local.system_bucket
   key    = "${local.prefix}/thin-egress-app/${local.prefix}-bucket_map.yaml"

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -23,7 +23,7 @@ module "thin_egress_app" {
   urs_auth_creds_secret_name         = aws_secretsmanager_secret.thin_egress_urs_creds.name
   use_cors                           = var.use_cors
   vpc_subnet_ids                     = data.aws_subnets.subnet_ids.ids
-  tags                               = local.default_tags
+  tags                               = merge(local.default_tags, {DAR = "YES"})
 }
 
 resource "aws_secretsmanager_secret" "thin_egress_urs_creds" {

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -23,7 +23,7 @@ module "thin_egress_app" {
   urs_auth_creds_secret_name         = aws_secretsmanager_secret.thin_egress_urs_creds.name
   use_cors                           = var.use_cors
   vpc_subnet_ids                     = data.aws_subnets.subnet_ids.ids
-  tags                               = merge(local.default_tags, {DAR = "YES"})
+  tags                               = local.default_tags
 }
 
 resource "aws_secretsmanager_secret" "thin_egress_urs_creds" {

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -152,16 +152,6 @@ variable "urs_client_password" {
 
 # Optional
 
-variable "urs_tea_client_id" {
-  type = string
-  default = null
-}
-
-variable "urs_tea_client_password" {
-  type = string
-  default = null
-}
-
 variable "api_gateway_stage" {
   type        = string
   default     = "dev"
@@ -428,6 +418,18 @@ variable "egress_lambda_log_retention_days" {
   type        = number
   default     = 30
   description = "Number of days to retain TEA logs"
+}
+
+variable "urs_tea_client_id" {
+  type = string
+  default = null
+  description = "The EarthData ID passed into the TEA module for URS authentication. If not provided, the value of urs_client_id will be used."
+}
+
+variable "urs_tea_client_password" {
+  type = string
+  default = null
+  description = "The EarthData password passed into the TEA module for URS authentication. If not provided, the value of urs_client_password will be used."
 }
 
 variable "cmr_acl_based_credentials" {

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -152,6 +152,16 @@ variable "urs_client_password" {
 
 # Optional
 
+variable "urs_tea_client_id" {
+  type = string
+  default = null
+}
+
+variable "urs_tea_client_password" {
+  type = string
+  default = null
+}
+
 variable "api_gateway_stage" {
   type        = string
   default     = "dev"

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -356,6 +356,12 @@ variable "ecs_cluster_instance_docker_volume_size" {
   default     = 50
 }
 
+variable "ecs_include_docker_cleanup_cronjob" {
+  description = "*Experimental* flag to configure a cron to run fstrim on all active container root filesystems"
+  type        = bool
+  default     = false
+}
+
 variable "bucket_map" {
   type    = map(object({ name = string, type = string }))
   default = {}


### PR DESCRIPTION
We're working to get from our fork back to the asfadmin/CIRRUS-core baseline.  These are a few of the smaller changes we had made on our fork.  These changes should not result in changed default behavior.  The changes include:

- Adding urs_tea_client_id and urs_tea_client_password to specify alternative client id and password for use in TEA.  If not specified, this defaults to urs_client_password/id variables.
- Adding optional ecs_include_docker_cleanup_cronjob, which defaults to False
- Fixing the value of report_granules_sns_topic_arn, updating it from module.cumulus.report_executions_sns_topic_arn to module.cumulus.report_granules_sns_topic_arn.
- Adding `{DAR = "YES"}` to the list of tags passed into TEA for use in the buckets created by this module
- Updated TEA bucket map so we do not redeploy the bucket map file if the file name is specified.  