### PR TITLE
Use aws provider level `default_tags` configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * add .gitconfig file to Docker image to mark /CIRRUS-core and /CIRRUS-DAAC as safe
+* Tag resources using the aws provider level `default_tags` configuration
 
 ## v18.3.1.1
 * Update the Makefile so that `make image` can be run without having set any

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -116,8 +116,6 @@ module "cumulus" {
   }]
 
   ecs_include_docker_cleanup_cronjob = var.ecs_include_docker_cleanup_cronjob
-
-  tags = local.default_tags
 }
 
 resource "aws_security_group" "no_ingress_all_egress" {
@@ -130,6 +128,4 @@ resource "aws_security_group" "no_ingress_all_egress" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  tags = local.default_tags
 }

--- a/cumulus/provider.tf
+++ b/cumulus/provider.tf
@@ -17,6 +17,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }

--- a/cumulus/thin-egress.tf
+++ b/cumulus/thin-egress.tf
@@ -23,13 +23,11 @@ module "thin_egress_app" {
   urs_auth_creds_secret_name         = aws_secretsmanager_secret.thin_egress_urs_creds.name
   use_cors                           = var.use_cors
   vpc_subnet_ids                     = data.aws_subnets.subnet_ids.ids
-  tags                               = local.default_tags
 }
 
 resource "aws_secretsmanager_secret" "thin_egress_urs_creds" {
   name_prefix = "${local.prefix}-tea-urs-creds-"
   description = "URS credentials for the ${local.prefix} Thin Egress App"
-  tags        = local.default_tags
 }
 
 resource "aws_secretsmanager_secret_version" "thin_egress_urs_creds" {
@@ -53,7 +51,6 @@ resource "aws_s3_object" "bucket_map_yaml" {
     protected_buckets = local.protected_bucket_names,
     public_buckets    = local.public_bucket_names
   }))
-  tags = local.default_tags
 }
 
 resource "aws_cloudwatch_log_subscription_filter" "egress_api_gateway_log_subscription_filter" {
@@ -70,7 +67,6 @@ resource "aws_cloudwatch_log_group" "egress_lambda_log_group" {
   count             = (var.log_destination_arn != null) ? 1 : 0
   name              = "/aws/lambda/${module.thin_egress_app.egress_lambda_name}"
   retention_in_days = var.egress_lambda_log_retention_days
-  tags              = local.default_tags
 }
 
 # Egress Lambda Log Group Filter

--- a/cumulus/throttled-queue.tf
+++ b/cumulus/throttled-queue.tf
@@ -2,13 +2,11 @@ resource "aws_sqs_queue" "background_job_queue" {
   name                       = "${local.prefix}-backgroundJobQueue"
   receive_wait_time_seconds  = 20
   visibility_timeout_seconds = 60
-  tags                       = local.default_tags
 }
 
 resource "aws_cloudwatch_event_rule" "background_job_queue_watcher" {
   name                = "${local.prefix}-background_job_queue_watcher"
   schedule_expression = "rate(1 minute)"
-  tags                = local.default_tags
 }
 
 resource "aws_cloudwatch_event_target" "background_job_queue_watcher" {

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -11,6 +11,4 @@ module "data_persistence" {
   permissions_boundary_arn   = local.permissions_boundary_arn
   rds_user_access_secret_arn = data.terraform_remote_state.rds.outputs.rds_user_access_secret_arn
   rds_security_group_id      = data.terraform_remote_state.rds.outputs.rds_security_group_id
-
-  tags = local.default_tags
 }

--- a/data-persistence/provider.tf
+++ b/data-persistence/provider.tf
@@ -13,6 +13,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }

--- a/tf/locals.tf
+++ b/tf/locals.tf
@@ -4,7 +4,10 @@ locals {
   aws_account_id_last4 = substr(data.aws_caller_identity.current.account_id, -4, 4)
 
   default_tags = {
-    Deployment = local.prefix,
-    DAR        = "YES"
+    Deployment = local.prefix
+  }
+
+  dar_yes_tags = {
+    DAR = "YES"
   }
 }

--- a/tf/main.tf
+++ b/tf/main.tf
@@ -3,7 +3,7 @@ resource "aws_s3_bucket" "backend-tf-state-bucket" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = local.default_tags
+  tags = local.dar_yes_tags
 }
 
 resource "aws_s3_bucket_versioning" "backend-tf-state-bucket-versioning" {
@@ -24,5 +24,4 @@ resource "aws_dynamodb_table" "backend-tf-locks-table" {
   lifecycle {
     prevent_destroy = true
   }
-  tags = local.default_tags
 }

--- a/tf/provider.tf
+++ b/tf/provider.tf
@@ -8,6 +8,9 @@ terraform {
 }
 
 provider "aws" {
+  default_tags {
+    tags = local.default_tags
+  }
   ignore_tags {
     key_prefixes = ["gsfc-ngap"]
   }


### PR DESCRIPTION
This even applies to resources created within the cumulus modules, so we no longer need to pass the default tags in through the `tags` variable for the `cumulus` and `data-persistence` modules.

NOTE: This will generate a terraform diff for existing tagged resources because terraform tracks two separate `tags*` fields. `tags` are the resource specific tags which will no longer include the deployment tag while `tags_all` will include the resource specific tags merged together with the provider level defaults. Diffs should show that the `tags` field had the `Deployment` tag removed, while `tags_all` should remain unchanged (or in some cases have the `Deployment` tag added if that resource was not tagged before).