### PR TITLE
fix: uncomment Copy .gitconfig line 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ ARG USER
 RUN \
         echo "user:x:${USER}:0:root:/:/bin/bash" >> /etc/passwd
 
-#COPY .gitconfig /.gitconfig
+COPY .gitconfig /.gitconfig
 
 WORKDIR /CIRRUS-core
 


### PR DESCRIPTION
I did not mean to comment this out. On that note, it does make our CI/CD pipeline fail. Is any other DAAC having an issue with it and their CI/CID pipeline?