### PR TITLE
PR-6094 Add Docker-in-Docker support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
+* Add 'Docker in Docker' functionality by giving the container access to the
+  host's docker engine. This requires running `make docker-in-docker-permissions`
 
 ## v18.3.3.0
 * Upgrade to [Cumulus v18.3.3](https://github.com/nasa/cumulus/releases/tag/v18.3.3)

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM public.ecr.aws/lambda/python:3.9 as python3
 #   * Yarn
 #   * AWS CLI
 #   * Terraform
+#   * Docker
 
 # Amazon Linux 2 does not support node 18.x or node 20.x glibc=2.27 and >=2.28 is required
 ENV NODE_VERSION "16.x"
@@ -22,14 +23,17 @@ RUN \
         yum update -y
 
 # CLI utilities
-RUN yum install -y gcc gcc-c++ git make openssl unzip wget zip jq
+RUN yum install -y gcc gcc-c++ git make openssl unzip zip jq docker
 
-# AWS & Terraform
+# Terraform
 RUN \
-        wget "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
-        unzip *.zip && \
+        curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o "terraform.zip" && \
+        unzip terraform.zip && \
         chmod +x terraform && \
-        mv terraform /usr/local/bin && \
+        mv terraform /usr/local/bin
+
+# AWS CLI
+RUN \
         curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-$AWS_CLI_VERSION.zip" -o "awscliv2.zip" && \
         unzip awscliv2.zip && \
         ./aws/install
@@ -40,7 +44,7 @@ RUN \
 
 # SSM SessionManager plugin
 RUN \
-        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm" &&\
+        curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/linux_64bit/session-manager-plugin.rpm" -o "session-manager-plugin.rpm" && \
         yum install -y session-manager-plugin.rpm
 
 # Add user for keygen in Makefile

--- a/Makefile
+++ b/Makefile
@@ -78,9 +78,14 @@ container-shell:
 		-v ${DAAC_DIR}:/CIRRUS-DAAC \
 		-v ${HOME}/.aws:/.aws \
 		-v ${HOME}/.cache/pip:/.cache/pip \
+		-v /var/run/docker.sock:/var/run/docker.sock \
 		--name=cirrus-core \
 		cirrus-core:$(DOCKER_TAG) \
 		bash
+
+.PHONY: docker-in-docker-permissions
+docker-in-docker-permissions:
+	sudo chmod 666 /var/run/docker.sock
 
 # ---------------------------
 .PHONY: tf-init

--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ Documentation](https://nasa.github.io/cumulus/docs/deployment/deployment-readme)
 for detailed information about configuring, deploying, and running
 Cumulus.
 
-## Generating Releases 
+## Generating Releases
 
 ### Naming Schema:
-The CIRRUS name schema is `vX.X.X.Y`. The X represents the [Cumulus version](https://github.com/nasa/cumulus/releases), 
-while the Y represents the CIRRUS version. 
+The CIRRUS name schema is `vX.X.X.Y`. The X represents the [Cumulus version](https://github.com/nasa/cumulus/releases),
+while the Y represents the CIRRUS version.
 
 ### Backporting Features
-A release branch should be created when backporting a feature, such as `release/v17.1.4.2`. 
-In this case, the release branch `release/v17.1.4.2` should be created from the tag `v17.1.4.1`. 
-You should then create a PR from your feature branch to the release branch. 
-Once the PR has been approved and merged, you can create a release based on the release branch. 
+A release branch should be created when backporting a feature, such as `release/v17.1.4.2`.
+In this case, the release branch `release/v17.1.4.2` should be created from the tag `v17.1.4.1`.
+You should then create a PR from your feature branch to the release branch.
+Once the PR has been approved and merged, you can create a release based on the release branch.
 
 ## Prerequisites
 
@@ -62,6 +62,21 @@ You can start an interactive Docker container session and use this to run tests 
         $ make image
         $ make container-shell
 
+
+### Docker-in-Docker Support
+
+By default the container shell will run with the docker socket
+(`/var/run/docker.sock`) mounted to the host to allow commands inside the
+container to talk to the host docker daemon. This might be needed if you want to
+build and push docker container images to Amazon ECR for instance.
+
+It is highly likely that your docker socket will have restrictive permissions by
+default that prevent it from being accessible within the container shell. You
+can fix these permissions by running
+
+        $ make docker-in-docker-permissions
+
+on your host machine before entering the container shell.
 
 ## Organization
 
@@ -155,7 +170,7 @@ secrets files will *not* (and *should not*) be committed to git. The
 
 3. Deploy Cumulus. If this is your first Cumulus deployment for this
    stack, deploy the entire Cumulus stack:
-   
+
 
       $ make initial-deploy
 


### PR DESCRIPTION
Method taken from here: https://devopscube.com/run-docker-in-docker/

This method works well for pulling/pushing images but things get weird when you need to interact with the host filesystem such as when mounting a docker volume. The files mounted to the inner container will come directly from the host system and not from within the CIRRUS-core container. This makes writing the correct paths in the makefile a lot more tricky, since volume mounts want an absolute path and the absolute path on the host vs inside the container will not be the same.

We need this for ASF to be able to deploy some of our workflows that build and push container images to ECR for our step function activity tasks. Our CI has it set up already because it builds and runs the container image using a different command, but for local development we would want this capability in the CIRRUS-core makefile.