### PR TITLE
Python 3.9 Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * add .gitconfig file to Docker image to mark /CIRRUS-core and /CIRRUS-DAAC as safe
+
+## v18.3.1.1
 * Update the Makefile so that `make image` can be run without having set any
   environment variables.
 * update core image to build from aws/lambda/python:3.9 as the python3 target

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * add .gitconfig file to Docker image to mark /CIRRUS-core and /CIRRUS-DAAC as safe
 * Update the Makefile so that `make image` can be run without having set any
   environment variables.
+* update core image to build from aws/lambda/python:3.9 as the python3 target
 
 ## v18.3.1.0
 * Added separate urs_tea_client_id and urs_tea_client_password that can be specified if these are different from the non-tea versions of the variables.
@@ -18,7 +19,7 @@ specified log group already exists" error: `make import-thin-egress-log`
 * Update Dockerfile:
   * FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
   * LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format
-  * NODE_VERSION="20.x"  
+  * NODE_VERSION="20.x"
   * TERRAFORM_VERSION="1.9.2"
   * AWS_CLI_VERSION="2.17.13"
   * Upgrade to amazonlinux:2023 from amazonlinux:2


### PR DESCRIPTION
This uses the AWS Lambda image for python 3.9
Node is set to 16.x because node 18.x and 20.x require glibc>=2.28 and 2.27 is present on amazon linux 2

Rather than try and install node 18.x or 20.x on amazon linux 2 we can keep what we had as the primary use I have seen is to deploy the cumulus dashboard. 

This is a resolution to a dependency layer issue ASF encounter while building on amazon linux 2023. 
Ideally once CMA can be built on python 3.12 we can update to the amazon linxu 2023 and use python 3.12 and node 20.x 

