### PR TITLE
PR-6139 Update CIRRUS-core to v18.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+## v18.5.0.0
+* Upgrade to [Cumulus v18.5.0](https://github.com/nasa/cumulus/releases/tag/v18.5.0)
+* **NOTE** This version of Cumulus requires changes to the RDS database
+* For Serverless v2 RDS migration please see the cumulus [instructions](https://nasa.github.io/cumulus/docs/next/upgrade-notes/serverless-v2-upgrade/)
+
 ## v18.4.0.0
 * Upgrade to [Cumulus v18.4.0](https://github.com/nasa/cumulus/releases/tag/v18.4.0)
 * Add 'Docker in Docker' functionality by giving the container access to the

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@
 #  PYTHON_VER:            python3
 
 # ---------------------------
-DOCKER_TAG := v18.4.0.0
+DOCKER_TAG := v18.5.0.0
 export TF_IN_AUTOMATION="true"
 export TF_VAR_MATURITY=${MATURITY}
 export TF_VAR_DEPLOY_NAME=${DEPLOY_NAME}

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.4.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.5.0/terraform-aws-cumulus.zip/tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -1,5 +1,5 @@
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.4.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.5.0/terraform-aws-cumulus.zip/tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnets.subnet_ids.ids


### PR DESCRIPTION
Seems like the most of the changes are coming in v18.5.0 of DAAC. RDS module has some changes.
This release is for severless v2 upgrade of cumulus. A fixes are in the release notes. https://github.com/nasa/cumulus/releases/tag/v18.5.0 