### PR TITLE
fix: terraform subdirectory access in module source

### DIFF
--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -1,5 +1,5 @@
 module "cumulus" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.5.0/terraform-aws-cumulus.zip/tf-modules/cumulus"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.5.0/terraform-aws-cumulus.zip//tf-modules/cumulus"
 
   cumulus_message_adapter_lambda_layer_version_arn = data.terraform_remote_state.daac.outputs.cma_layer_arn
 

--- a/data-persistence/main.tf
+++ b/data-persistence/main.tf
@@ -1,5 +1,5 @@
 module "data_persistence" {
-  source = "https://github.com/nasa/cumulus/releases/download/v18.5.0/terraform-aws-cumulus.zip/tf-modules/data-persistence"
+  source = "https://github.com/nasa/cumulus/releases/download/v18.5.0/terraform-aws-cumulus.zip//tf-modules/data-persistence"
 
   prefix                = local.prefix
   subnet_ids            = data.aws_subnets.subnet_ids.ids


### PR DESCRIPTION
This was introduced in previous v18.5.0.0 release. Plan to fix: delete v18.5.0.0 release and then re-generate the release after this is merged. 
