### PR TITLE
add outputs for rds_lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
+* add cumulus outputs to allow deployment of the (rds_lambda)[https://github.com/ghrcdaac/ghrc_rds_lambda]
+which is used as a plugin for (PyLOT)[https://github.com/ghrcdaac/cloud-operations-tool-py]
 
 ## v18.5.1.0
 * Upgrade to [Cumulus v18.5.1](https://github.com/nasa/cumulus/releases/tag/v18.5.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # CHANGELOG
 
 ## Unreleased
-* add cumulus outputs to allow deployment of the (rds_lambda)[https://github.com/ghrcdaac/ghrc_rds_lambda]
-which is used as a plugin for (PyLOT)[https://github.com/ghrcdaac/cloud-operations-tool-py]
+* add cumulus outputs to allow deployment of the [rds_lambda](https://github.com/ghrcdaac/ghrc_rds_lambda)
+which is used as a plugin for [PyLOT](https://github.com/ghrcdaac/cloud-operations-tool-py)
 
 ## v18.5.1.0
 * Upgrade to [Cumulus v18.5.1](https://github.com/nasa/cumulus/releases/tag/v18.5.1)

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -49,6 +49,10 @@ output "pdr_status_check_task" {
   value = module.cumulus.pdr_status_check_task
 }
 
+output "provider_kms_key_id" {
+  value = module.cumulus.provider_kms_key_id
+}
+
 output "queue_granules_task" {
   value = module.cumulus.queue_granules_task
 }
@@ -79,6 +83,9 @@ output "sqs2sfThrottle_lambda_function_arn" {
 
 # ---------
 # Cumulus IAM Resources
+output "lambda_processing_role_name" {
+  value = module.cumulus.lambda_processing_role_name
+}
 output "lambda_processing_role_arn" {
   value = module.cumulus.lambda_processing_role_arn
 }


### PR DESCRIPTION
I have been playing with GHRC's [PyLot tool](https://github.com/ghrcdaac/cloud-operations-tool-py), in particular the [rds_lambda](https://github.com/ghrcdaac/ghrc_rds_lambda) plugin which allows querying of the Cumulus tables using the [AWS Data API](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/data-api.html).  To deploy the lambda requires a couple extra Cumulus outputs.