### PR TITLE
PR-6400 Clean up makefile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+* Remove `figlet` and `banner` from the `Making ...` banner.
 
 ## v20.0.0.0
 * Upgrade to [Cumulus v20.0.0](https://github.com/nasa/cumulus/releases/tag/v20.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 * Remove `figlet` and `banner` from the `Making ...` banner.
+* Remove unused `null` and `archive` provider from `cumulus` and
+`data-persistence` modules.
 
 ## v20.0.0.0
 * Upgrade to [Cumulus v20.0.0](https://github.com/nasa/cumulus/releases/tag/v20.0.0)

--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,7 @@ SELF_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 define banner =
 echo
 echo "========================================"
-if command -v figlet 2>/dev/null; then
-	figlet $@
-elif command -v banner 2>/dev/null; then
-	banner $@
-else
-	echo "Making: $@"
-fi
+echo "Making: $@"
 echo "========================================"
 endef
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Once the PR has been approved and merged, you can create a release based on the 
 
 ## Prerequisites
 
-* [GNU Make](https://www.gnu.org/software/make/)
+* [GNU Make](https://www.gnu.org/software/make/) v4.x
 * [Docker](https://www.docker.com/get-started)
 * One or more NGAP accounts (sandbox, SIT, ...)
 * AWS credentials for those account(s)

--- a/cumulus/provider.tf
+++ b/cumulus/provider.tf
@@ -4,14 +4,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 2.1"
-    }
-    archive = {
-      source  = "hashicorp/archive"
-      version = "~> 2.2.0"
-    }
   }
   backend "s3" {}
 }

--- a/data-persistence/provider.tf
+++ b/data-persistence/provider.tf
@@ -4,10 +4,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "~> 5.0"
     }
-    null = {
-      source  = "hashicorp/null"
-      version = "~> 2.1"
-    }
   }
   backend "s3" {}
 }


### PR DESCRIPTION
`banner` was causing a horribly large banner to be printed on some MacOS systems. Since this is just a cutesy cosmetic feature that doesn't even get used in the docker version (because nether `figlet` nor `banner` are installed in the container) I am removing it to reduce unexpected differences in the output when deploying directly from the host.

The `null` provider version 2 was causing issues on arm based Mac machines since that old provider version didn't have any macos-arm builds. Since the provider is unused I just removed it rather than bumping to version 3.