### PR TITLE
Remove openssl and Docker

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/checkout@v2
       name: Checkout source code
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v4
       name: Cache plugin dir
       with:
         path: ~/.tflint.d/plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Remove `figlet` and `banner` from the `Making ...` banner.
 * Remove unused `null` and `archive` provider from `cumulus` and
 `data-persistence` modules.
+* Removed installing openssl and docker in Dockefile
 
 ## v20.0.0.0
 * Upgrade to [Cumulus v20.0.0](https://github.com/nasa/cumulus/releases/tag/v20.0.0)

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN \
         yum update -y
 
 # CLI utilities
-RUN yum install -y gcc gcc-c++ git make openssl unzip zip jq docker
+RUN yum install -y gcc gcc-c++ git make unzip zip jq
 
 # Terraform
 RUN \


### PR DESCRIPTION
It seems like Amazon updated something on their end that clashes when `openssl` is installed. Jon Velapoldi noted that `openssl-snapsafe-libs` is already installed on the base image, so I tested removing the openssl install in the Dockerfile. It worked with no issues. I am also removing the Docker install in the Dockerfile. When I was working on bignbit, I noticed it was never actually being installed. 