### PR TITLE
PR-6290 Rename default branch to 'main'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -552,7 +552,7 @@ in the TEA migration instructions (<https://nasa.github.io/cumulus/docs/upgrade-
 ### Notes about v3.0.0 migration as relates to CIRRUS
 
 * The `make daac` step of this version of CIRRUS generates a new output (`bucket_map_key`).  Look at the corresponding
-[CIRRUS-DAAC](https://github.com/asfadmin/CIRRUS-DAAC/blob/master/daac/outputs.tf) to add that value to your `daac/outputs.tf` file and then run `make daac`
+[CIRRUS-DAAC](https://github.com/asfadmin/CIRRUS-DAAC/blob/main/daac/outputs.tf) to add that value to your `daac/outputs.tf` file and then run `make daac`
 * Where the TEA migration instructions mention `terraform plan` use the new `make plan-cumulus` target get the output mentioned
 * Run `make daac` and `make data-persistence` prior to `make plan-cumulus`
 * Normally you run all CIRRUS `make` commands from the root `CIRRUS-core` directory.  All the `terraform state mv *` commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+# Unreleased
+* Update default GitHub branch name to 'main'
+
 # v20.1.1.0
 * Upgrade to [Cumulus v20.1.1](https://github.com/nasa/cumulus/releases/tag/v20.1.1)
 * Added throttled_queues variable to cumulus

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To deploy your own Cumulus stack, first fork the
 rename it for your deployment. For example, you might name it
 `ASF-Cumulus`. Next, customize the Terraform and variable settings in
 your new `CIRRUS-DAAC`-forked repository. See its
-[README](https://github.com/asfadmin/CIRRUS-DAAC/blob/master/README.md)
+[README](https://github.com/asfadmin/CIRRUS-DAAC/blob/main/README.md)
 for more details.
 
 ## Deploying Cumulus
@@ -169,7 +169,7 @@ account.
         (This assumes we've setup a named AWS credentials profile with the name `xyz-sandbox-cumulus`)
 
 4. See the [CIRRUS-DAAC
-  README's](https://github.com/asfadmin/CIRRUS-DAAC/blob/master/README.md)
+  README's](https://github.com/asfadmin/CIRRUS-DAAC/blob/main/README.md)
   instructions for creating local secrets files. These will be files
   located in the DAAC directory, and as the note describes below, are
   **NOT** to be checked in to git!
@@ -216,6 +216,6 @@ If you want to deploy everything besides the `rds` module you can run the comman
 migration instructions (if any).  The Cumulus instructions are generally included
 in the [release notes](https://github.com/nasa/cumulus/releases).  CIRRUS
 instructions would be included in the CHANGELOG for
-[CIRRUS-core](https://github.com/asfadmin/CIRRUS-core/blob/master/CHANGELOG.md)
+[CIRRUS-core](https://github.com/asfadmin/CIRRUS-core/blob/main/CHANGELOG.md)
 and
-[CIRRUS-DAAC](https://github.com/asfadmin/CIRRUS-DAAC/blob/master/CHANGELOG.md).
+[CIRRUS-DAAC](https://github.com/asfadmin/CIRRUS-DAAC/blob/main/CHANGELOG.md).


### PR DESCRIPTION
This is part of an ASF I&A effort to have all our repos using the same default branch name.