### PR TITLE
Add dynamic_throttled_queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 * Update `cumulus` module to allow for optional use of AWS Secrets Manager for `archive_api_url, urs_client_password, metrics_es_password, cmr_password, cmr_username, lzards_launchpad_passphrase, launchpad_passphrase, token_secret` via `configuration_secret` variable
 * Update GH actions `tflint` to v0.61.0, update GH actions `checkout` to v4
-
+* Add `send_pan_task` to `cumulus` module output
+* Update Docker image to install docker CLI 
+* Update Makefile to allow docker-in-docker on MacOS hosts
 
 ## v21.0.1.0
 * Updrade to [Cumulus v21.0.1](https://github.com/nasa/cumulus/releases/tag/v21.0.1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Add dynamic_throttled_queues to allow for throttled queues with configurable names to be defined according to the pattern: https://sqs.${data.aws_region.current.name}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.prefix}-${q.queue_name}.   This allows for queue configurations to be defined programatically for similar deployments across deployment/account/regions/etc.
+
 * Upgrade to [Cumulus v21.2.0](https://github.com/nasa/cumulus/releases/tag/v21.2.0)
 * add variable "archive_records_config" to cumulus/variables.tf
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,15 @@ RUN \
         curl -sL https://dl.yarnpkg.com/rpm/yarn.repo | tee /etc/yum.repos.d/yarn.repo && \
         yum update -y
 
+# Add Docker
+
+ARG DOCKER_VERSION=25.0.5
+RUN yum install gzip -y && yum install tar -y
+RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+  | tar -xz -C /usr/local/bin --strip-components=1 docker/docker \
+ && docker --version
+ENV DOCKER_CONFIG=/tmp/.docker
+RUN mkdir -p "$DOCKER_CONFIG" && chmod 1777 "$DOCKER_CONFIG"
 # CLI utilities
 RUN yum install -y gcc gcc-c++ git make unzip zip jq
 
@@ -90,6 +99,15 @@ RUN \
 # CLI utilities
 RUN yum install -y gcc gcc-c++ git make unzip zip jq
 
+# Add Docker
+
+ARG DOCKER_VERSION=25.0.5
+RUN yum install gzip -y && yum install tar -y
+RUN curl -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz" \
+  | tar -xz -C /usr/local/bin --strip-components=1 docker/docker \
+ && docker --version
+ENV DOCKER_CONFIG=/tmp/.docker
+RUN mkdir -p "$DOCKER_CONFIG" && chmod 1777 "$DOCKER_CONFIG" 
 # Terraform
 RUN \
         curl "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" -o "terraform.zip" && \

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,6 @@ CIRRUS_DAAC_VERSION := $(or $(shell git -C $(DAAC_DIR) tag --points-at HEAD | he
 endif
 THIN_EGRESS_LOG_EXIST := "0"
 
-DOCKER_GID := $(shell \
-  if [ -S /var/run/docker.sock ]; then \
-    (stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null); \
-  fi)
-
 # ---------------------------
 SELF_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -64,11 +59,11 @@ image:
 
 .PHONY: container-shell
 container-shell:
-	DOCKER_GID=$$( (stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null) ); \
-	echo "DOCKER_GID=$$DOCKER_GID"; \
+	if [ "$$(uname -s)" = "Darwin" ]; then DOCKER_GID=0; else DOCKER_GID=""; fi; \
 	docker run -it --rm \
 		--platform linux/amd64 \
-        --user $$(id -u):0 \
+		--user `id -u`:`id -g` \
+		$${DOCKER_GID:+--group-add $$DOCKER_GID} \
 		--env DAAC_DIR="/CIRRUS-DAAC" \
 		--env AWS_CONFIG_DIR="/" \
 		--env DOCKER_CONFIG=/tmp/.docker \
@@ -96,6 +91,7 @@ shell:
 
 .PHONY: docker-in-docker-permissions
 docker-in-docker-permissions:
+    # Linux CI hosts compatibility: give group permissions to the docker socket. This allows the container to run docker commands without sudo, which is necessary for running `make image` from within the container. For MacOS hosts, this is a no-op since the docker socket is not used.
 	sudo chmod 666 /var/run/docker.sock
 
 # ---------------------------

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,11 @@ CIRRUS_DAAC_VERSION := $(or $(shell git -C $(DAAC_DIR) tag --points-at HEAD | he
 endif
 THIN_EGRESS_LOG_EXIST := "0"
 
+DOCKER_GID := $(shell \
+  if [ -S /var/run/docker.sock ]; then \
+    (stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null); \
+  fi)
+
 # ---------------------------
 SELF_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 
@@ -59,11 +64,14 @@ image:
 
 .PHONY: container-shell
 container-shell:
+	DOCKER_GID=$$( (stat -c '%g' /var/run/docker.sock 2>/dev/null || stat -f '%g' /var/run/docker.sock 2>/dev/null) ); \
+	echo "DOCKER_GID=$$DOCKER_GID"; \
 	docker run -it --rm \
 		--platform linux/amd64 \
-		--user `id -u`:`id -g` \
+        --user $$(id -u):0 \
 		--env DAAC_DIR="/CIRRUS-DAAC" \
 		--env AWS_CONFIG_DIR="/" \
+		--env DOCKER_CONFIG=/tmp/.docker \
 		--env PS1='\s-\v:\w\$$ ' \
 		--env HISTFILE="/CIRRUS-core/.container_bash_history" \
 		--env TF_VAR_CIRRUS_CORE_VERSION=${CIRRUS_CORE_VERSION} \
@@ -76,7 +84,7 @@ container-shell:
 		--name=cirrus-core \
 		cirrus-core:$(DOCKER_TAG) \
 		bash
-
+		
 .PHONY: shell
 shell:
 		DAAC_DIR="${DAAC_DIR}" \

--- a/cumulus/locals.tf
+++ b/cumulus/locals.tf
@@ -56,6 +56,13 @@ locals {
   
   urs_tea_client_id       = var.urs_tea_client_id != null ? var.urs_tea_client_id : local.urs_client_id
   urs_tea_client_password = var.urs_tea_client_password != null ? var.urs_tea_client_password : local.urs_client_password
+  
+  throttled_queues = [
+    for q in var.dynamic_throttled_queues : {
+      url             = "https://sqs.${data.aws_region.current.name}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.prefix}-${q.queue_name}"
+      execution_limit = q.execution_limit
+    }
+  ]
 }
 
 check "urs_client_id_required" {
@@ -92,3 +99,4 @@ check "token_secret_required" {
     error_message = "token_secret must be provided either via the configuration_secret or the token_secret variable."
   }
 }
+

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -105,7 +105,7 @@ module "cumulus" {
   throttled_queues = concat([{
     url             = aws_sqs_queue.background_job_queue.id,
     execution_limit = var.throttled_queue_execution_limit
-  }], var.throttled_queues)
+  }], var.throttled_queues, local.throttled_queues)
 
   ecs_include_docker_cleanup_cronjob = var.ecs_include_docker_cleanup_cronjob
 }

--- a/cumulus/outputs.tf
+++ b/cumulus/outputs.tf
@@ -62,6 +62,9 @@ output "queue_pdrs_task" {
 output "queue_workflow_task" {
   value = module.cumulus.queue_workflow_task
 }
+output "send_pan_task" {
+  value = module.cumulus.send_pan_task
+}
 output "sf_sqs_report_task" {
   value = module.cumulus.sf_sqs_report_task
 }

--- a/cumulus/variables.tf
+++ b/cumulus/variables.tf
@@ -537,3 +537,11 @@ variable "allow_provider_mismatch_on_rule_filter" {
   type = bool
   default = false
 }
+variable "dynamic_throttled_queues" {
+  type = list(object({
+    queue_name      = string
+    execution_limit = number
+  }))
+  default     = []
+  description = "List of SQS queue throttle configs. The queue_name is the suffix after the deployment prefix (e.g. 'ETQ-ASDC-StandardPdrJobs'). The full URL is constructed in locals.tf using local.prefix.  Result will be merged with `throttled queues`"
+}


### PR DESCRIPTION
This PR adds a way to dynamically configure throttled queues in cases where the same queue is being deployed across multiple deployments and/or accounts rather than redefining the queue per deployment. 