### PR TITLE
Add validation of deploy_name in env.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
 # CHANGELOG
 
 ## Unreleased
+
+## v21.3.3.0
+* Upgrade to [Cumulus v21.3.3](https://github.com/nasa/cumulus/releases/tag/v21.3.3)
 * Update Dockerfile python3 stage to use only node v22, remove all yum installs in favor of dnf
-* Add dynamic_throttled_queues to allow for throttled queues with configurable names to be defined according to the pattern: https://sqs.${data.aws_region.current.name}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.prefix}-${q.queue_name}.   This allows for queue configurations to be defined programatically for similar deployments across deployment/account/regions/etc.
+* Upgrade TEA to [v3.0.0](https://github.com/asfadmin/thin-egress-app/releases/tag/tea-release.3.0.0)
+* Add `dynamic_throttled_queues` to allow for throttled queues with configurable names to be defined according to the pattern: `https://sqs.${data.aws_region.current.name}.amazonaws.com/${data.aws_caller_identity.current.account_id}/${local.prefix}-${q.queue_name}`. This allows for queue configurations to be defined programatically for similar deployments across deployment/account/regions/etc.
+* Add `archive_records_config`
+* Add `sync_granule_s3_jitter_max_ms`
+* Add `allow_provider_mismatch_on_rule_filter`
 
 ## v21.3.2.0
 * Upgrade to [Cumulus v21.3.2](https://github.com/nasa/cumulus/releases/tag/v21.3.2)

--- a/cumulus/main.tf
+++ b/cumulus/main.tf
@@ -10,6 +10,8 @@ module "cumulus" {
 
   deploy_to_ngap = true
 
+  allow_provider_mismatch_on_rule_filter = var.allow_provider_mismatch_on_rule_filter
+
   ecs_cluster_instance_image_id = var.ecs_cluster_instance_image_id != "" ? var.ecs_cluster_instance_image_id : data.aws_ssm_parameter.ecs_image_id.value
 
   ecs_cluster_instance_subnet_ids         = data.aws_subnets.subnet_ids.ids
@@ -18,6 +20,8 @@ module "cumulus" {
   ecs_cluster_max_size                    = var.ecs_cluster_max_size
   ecs_cluster_instance_type               = var.ecs_cluster_instance_type
   ecs_cluster_instance_docker_volume_size = var.ecs_cluster_instance_docker_volume_size
+
+  ecs_include_docker_cleanup_cronjob = var.ecs_include_docker_cleanup_cronjob
 
   key_name = var.key_name
 
@@ -73,6 +77,8 @@ module "cumulus" {
   archive_api_users = var.api_users
   archive_api_url   = local.archive_api_url
 
+  sync_granule_s3_jitter_max_ms = var.sync_granule_s3_jitter_max_ms
+
   orca_lambda_copy_to_archive_arn = local.orca_lambda_copy_to_archive_arn
   orca_sfn_recovery_workflow_arn  = local.orca_sfn_recovery_workflow_arn
   orca_api_uri                    = local.orca_api_uri
@@ -107,7 +113,7 @@ module "cumulus" {
     execution_limit = var.throttled_queue_execution_limit
   }], var.throttled_queues, local.throttled_queues)
 
-  ecs_include_docker_cleanup_cronjob = var.ecs_include_docker_cleanup_cronjob
+  archive_records_config = var.archive_records_config
 }
 
 resource "aws_security_group" "no_ingress_all_egress" {

--- a/env.sh
+++ b/env.sh
@@ -3,6 +3,16 @@
 if (( $# != 3 )); then
     echo "Usage: source env.sh aws_profile_name deploy_name maturity"
 else
+    if (( ${#2} > 10 )); then
+        echo "Error: deploy_name must be 10 characters or fewer."
+        return 1 2>/dev/null || exit 1
+    fi
+
+    if [[ ! "$2" =~ ^[a-z0-9-]+$ ]]; then
+        echo "Error: deploy_name may contain only lowercase letters, numbers, and hyphens."
+        return 1 2>/dev/null || exit 1
+    fi
+
     export AWS_PROFILE=$1
 
     AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile "$AWS_PROFILE")


### PR DESCRIPTION
There is a note on the [Consolidated Cumulus deployment wiki](https://wiki.earthdata.nasa.gov/pages/viewpage.action?pageId=508725235&spaceKey=CCOMIT&title=Developer%2BStack%2BCreation%2Bin%2BCC-SIT%2Busing%2BWindows%2BSubsystem%2Bfor%2BLinux%2B2%2BWSL2#expand-Sourcetheenvironment):
```
Prefix Choice
During initial deployment, we ran into an error due to the maximum length of a resource name, 
so you will want to keep this prefix relatively short if choosing something other than this convention. 
```
We should add the prefix check in the script itself so that people don't run into the error far into the deployment only to find out that their prefix choice is too long and it takes hours to rewind the deployment and try again.

Add validation of deploy_name in env.sh so that we can avoid time consuming deployment errors later.