### PR TITLE
Add validation of deploy_name in env.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## Unreleased
+* Add validation of deploy_name in env.sh
 
 ## v22.2.1.0
 * Upgrade to [Cumulus v22.2.1](https://github.com/nasa/cumulus/releases/tag/v22.2.1)

--- a/env.sh
+++ b/env.sh
@@ -3,6 +3,16 @@
 if (( $# != 3 )); then
     echo "Usage: source env.sh aws_profile_name deploy_name maturity"
 else
+    if (( ${#2} > 10 )); then
+        echo "Error: deploy_name must be 10 characters or fewer."
+        return 1 2>/dev/null || exit 1
+    fi
+
+    if [[ ! "$2" =~ ^[a-z0-9-]+$ ]]; then
+        echo "Error: deploy_name may contain only lowercase letters, numbers, and hyphens."
+        return 1 2>/dev/null || exit 1
+    fi
+
     export AWS_PROFILE=$1
 
     AWS_ACCESS_KEY_ID=$(aws configure get aws_access_key_id --profile "$AWS_PROFILE")


### PR DESCRIPTION
There is a note on the [Consolidated Cumulus deployment wiki](https://wiki.earthdata.nasa.gov/pages/viewpage.action?pageId=508725235&spaceKey=CCOMIT&title=Developer%2BStack%2BCreation%2Bin%2BCC-SIT%2Busing%2BWindows%2BSubsystem%2Bfor%2BLinux%2B2%2BWSL2#expand-Sourcetheenvironment):
```
Prefix Choice
During initial deployment, we ran into an error due to the maximum length of a resource name, 
so you will want to keep this prefix relatively short if choosing something other than this convention. 
```
We should add the prefix check in the script itself so that people don't run into the error far into the deployment only to find out that their prefix choice is too long and it takes hours to rewind the deployment and try again.

Add validation of deploy_name in env.sh so that we can avoid time consuming deployment errors later.